### PR TITLE
Fixes OAuth token to not be applied as a default header across the entire HttpClient.

### DIFF
--- a/MareSynchronos/WebAPI/Files/FileTransferOrchestrator.cs
+++ b/MareSynchronos/WebAPI/Files/FileTransferOrchestrator.cs
@@ -192,6 +192,10 @@ public class FileTransferOrchestrator : DisposableMediatorSubscriberBase
             var token = await _tokenProvider.GetToken().ConfigureAwait(false);
             requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
+        else
+        {
+            requestMessage.Headers.Authorization = null;
+        }
 
         if (requestMessage.Content != null && requestMessage.Content is not StreamContent && requestMessage.Content is not ByteArrayContent)
         {


### PR DESCRIPTION
In addition to breaking downloads from pre-signed object storage URLs, this should be considered a security fix as well - we don't want to give our Discord OAuth2 token to every server we send HTTP requests to.