### PR TITLE
1.14.2.2

### DIFF
--- a/PlayerSync/PlayerSync.csproj
+++ b/PlayerSync/PlayerSync.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>1.14.2.1</Version>
+    <Version>1.14.2.2</Version>
     <Description></Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/MareSynchronos/client</PackageProjectUrl>

--- a/PlayerSync/Plugin.cs
+++ b/PlayerSync/Plugin.cs
@@ -227,7 +227,7 @@ public sealed class Plugin : IDalamudPlugin
 
             collection.AddSingleton<VersionUpdateCheckService>();
             collection.AddSingleton<CacheMonitor>();
-            collection.AddSingleton<HubFactory>();
+            //collection.AddSingleton<HubFactory>(); why was this added twice?
 
             // add scoped services
             collection.AddScoped<DrawEntityFactory>();

--- a/PlayerSync/Services/DalamudUtilService.cs
+++ b/PlayerSync/Services/DalamudUtilService.cs
@@ -158,7 +158,7 @@ public class DalamudUtilService : IHostedService, IMediatorSubscriber
 
     public string TargetName
     {
-        get => _targetManager.Target?.Name.TextValue ?? "";
+        get => _targetManager.Target?.Name.TextValue ?? string.Empty;
     }
     public unsafe nint TargetAddress
     {

--- a/PlayerSync/Services/MareProfileManager.cs
+++ b/PlayerSync/Services/MareProfileManager.cs
@@ -48,7 +48,8 @@ public class MareProfileManager : MediatorSubscriberBase
             {
                 _mareProfiles.Remove(msg.UserData, out _);
                 var pair = _pairManager.GetPairByUID(msg.UserData.UID);
-                if (pair != null) pair.HasProfile = true;
+                if (pair != null && msg.UpdateProfileStatus) 
+                    pair.HasProfile = true;
             }
             else
                 _mareProfiles.Clear();

--- a/PlayerSync/Services/Mediator/Messages.cs
+++ b/PlayerSync/Services/Mediator/Messages.cs
@@ -78,7 +78,7 @@ public record ToggleCollapseMessage : MessageBase;
 public record PrefillJoinSyncshellParameters(string GroupId, bool ExpectPasswordless, bool IsGuestModeEnabled) : MessageBase;
 public record PreloadJoinSyncshellDtoMessage(GroupJoinInfoDto Dto, string Password) : MessageBase;
 public record PlayerUploadingMessage(GameObjectHandler Handler, bool IsUploading) : MessageBase;
-public record ClearProfileDataMessage(UserData? UserData = null) : MessageBase;
+public record ClearProfileDataMessage(UserData? UserData = null, bool UpdateProfileStatus = false) : MessageBase;
 public record UserPairStickyPauseAndRemoveMessage(UserData UserData) : MessageBase;
 public record CyclePauseMessage(UserData UserData) : MessageBase;
 public record PauseMessage(UserData UserData, PauseReason Reason) : MessageBase;

--- a/PlayerSync/UI/Components/ProfileBuilder.cs
+++ b/PlayerSync/UI/Components/ProfileBuilder.cs
@@ -43,7 +43,7 @@ public static class ProfileBuilder
         var inset = 3f * globalScale;
 
         var fillMin = new Vector2(leftX + inset, endY + inset);
-        var fillMax = new Vector2(rightX - inset, bottomY - inset);
+        var fillMax = new Vector2(rightX - inset, bottomY - inset * 0.5f);
 
         var min = new Vector2(windowPos.X + inset, startY - inset);
         var max = new Vector2(windowPos.X + windowSize.X - inset, endY + 5 * globalScale); // overlap a bit so no fractional pixel gaps
@@ -90,9 +90,9 @@ public static class ProfileBuilder
             return;
 
         var rounding = MathF.Max(0f, radiusPx * globalScale - inset);
-        var borderRounding = MathF.Max(0f, rounding - borderHalfThickness);
+        //var borderRounding = MathF.Max(0f, rounding - borderHalfThickness);
 
-        drawList.AddRect(borderMin, borderMax, ImGui.GetColorU32(borderColor), borderRounding, ImDrawFlags.RoundCornersAll, borderThickness);
+        drawList.AddRect(borderMin, borderMax, ImGui.GetColorU32(borderColor), rounding, ImDrawFlags.RoundCornersAll, borderThickness);
     }
 
     public static void DrawBackgroundImage(UiTheme theme, IDalamudTextureWrap? avatar, float portraitAspectW = 9f, float portraitAspectH = 16f, float insetPx = 3f)

--- a/PlayerSync/UI/IntroUI.cs
+++ b/PlayerSync/UI/IntroUI.cs
@@ -235,6 +235,13 @@ public partial class IntroUi : WindowMediatorSubscriberBase
             {
                 Ui.DrawHorizontalRule(_theme);
 
+                var rowY = ImGui.GetCursorPosY();
+
+                if (ImGui.Button("Setup Guide"))
+                {
+                    Util.OpenLink("https://docs.playersync.io/");
+                }
+
                 var idx = Array.IndexOf(_setupOrder, _currentSetupPageId);
                 var isFirst = idx <= 0;
                 var isLast = idx >= _setupOrder.Length - 1;
@@ -242,27 +249,31 @@ public partial class IntroUi : WindowMediatorSubscriberBase
                 var backLabel = "Back";
                 var nextLabel = "Next";
 
+                bool showBack = !(isFirst || _configService.Current.FirstTimeSetupComplete);
+                bool showNext = !_configService.Current.FirstTimeSetupComplete;
+
                 float ButtonWidth(string label) => ImGui.CalcTextSize(label).X + (style.FramePadding.X * 2f);
 
                 var spacing = style.ItemSpacing.X;
                 var backW = ButtonWidth(backLabel);
                 var nextW = ButtonWidth(nextLabel);
-                var totalW = (isFirst ? 0f : backW + spacing) + nextW;
+                var totalW = (showBack ? backW : 0f) + (showBack && showNext ? spacing : 0f) + (showNext ? nextW : 0f);
+
                 var max = ImGui.GetWindowContentRegionMax();
-                var y = max.Y - ImGui.GetFrameHeight() - padFooter - padBottom;
                 var x = max.X - totalW - padRight;
 
-                ImGui.SetCursorPosY(Math.Max(ImGui.GetCursorPosY(), y));
-                ImGui.SetCursorPosX(Math.Max(ImGui.GetCursorPosX(), x));
+                ImGui.SetCursorPos(new Vector2(x, rowY));
 
-                if (!(isFirst || _configService.Current.FirstTimeSetupComplete))
+                if (showBack)
                 {
                     if (ImGui.Button(backLabel))
                         PreviousPage();
-                    ImGui.SameLine();
+
+                    if (showNext)
+                        ImGui.SameLine();
                 }
 
-                if (!_configService.Current.FirstTimeSetupComplete)
+                if (showNext)
                 {
                     using (ImRaii.Disabled(!CanGoNextPage()))
                     {
@@ -414,8 +425,7 @@ public partial class IntroUi : WindowMediatorSubscriberBase
         else
         {
             UiSharedService.TextWrapped("To not unnecessary download files already present on your computer, PlayerSync will have to scan your Penumbra mod directory. " +
-                                    "Additionally, a local storage folder must be set where PlayerSync will download other character files to. " +
-                                    "Once the storage folder is set and the scan complete, this page will automatically forward to registration at a service.");
+                                    "Additionally, a local storage folder must be set where PlayerSync will download other character files to. ");
             UiSharedService.TextWrapped("Note: The initial scan, depending on the amount of mods you have, might take a while. Please wait until it is completed.");
             ImGuiHelpers.ScaledDummy(5);
             UiSharedService.ColorTextWrapped("Warning: once past this step you should not delete the FileCache.csv of PlayerSync in the Plugin Configurations folder of Dalamud. " +
@@ -430,8 +440,11 @@ public partial class IntroUi : WindowMediatorSubscriberBase
             {
                 _cacheMonitor.InvokeScan();
             }
-            ImGui.SameLine();
-            ImGui.TextUnformatted("(You must run the scan before proceeding.)");
+            if (!_configService.Current.InitialScanComplete)
+            {
+                ImGui.SameLine();
+                ImGui.TextUnformatted("(You must run the scan before proceeding.)");
+            }
         }
         else
         {

--- a/PlayerSync/UI/IntroUI.cs
+++ b/PlayerSync/UI/IntroUI.cs
@@ -495,7 +495,8 @@ public partial class IntroUi : WindowMediatorSubscriberBase
         }
 
         ImGuiHelpers.ScaledDummy(5);
-        ImGui.TextColoredWrapped(ImGuiColors.DalamudYellow, "Check \"Use Proxied Server\" if you had to use the mirror repo.");
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudRed, "Only use the Proxied Server option if the PlayerSync Support Team has advised it, " +
+            "or if you are experiencing persistent connection issues that normal troubleshooting hasn't resolved.");
         var useBackupServer = _serverConfigurationManager.EnableBackupServer;
         if (ImGui.Checkbox("Use Proxied Server", ref useBackupServer))
         {

--- a/PlayerSync/UI/PlayerAnalysisViewerUI.cs
+++ b/PlayerSync/UI/PlayerAnalysisViewerUI.cs
@@ -380,7 +380,10 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                 // time to draw table data.
                 foreach (var pair in sortedPairs)
                 {
-                    bool shouldHighlight = _dalamudUtilService.TargetName == pair.PlayerName;
+                    bool shouldHighlight = !string.IsNullOrWhiteSpace(_dalamudUtilService.TargetName)
+                        && !string.IsNullOrWhiteSpace(pair.PlayerName)
+                        && _dalamudUtilService.TargetName == pair.PlayerName;
+
                     float rowStartHeightStart = ImGui.GetCursorPosY();
 
                     ImGui.TableNextRow();
@@ -721,7 +724,9 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     bool ownAnimations = edit.IsDisableAnimations();
                     bool ownVfx = edit.IsDisableVFX();
                     
-                    bool shouldHighlight = _dalamudUtilService.TargetName == pair.PlayerName;
+                    bool shouldHighlight = !string.IsNullOrWhiteSpace(_dalamudUtilService.TargetName) 
+                        && !string.IsNullOrWhiteSpace(pair.PlayerName)
+                        && _dalamudUtilService.TargetName == pair.PlayerName;
 
                     // Track change for state
                     bool changed = false;

--- a/PlayerSync/UI/SettingsUi.Interface.cs
+++ b/PlayerSync/UI/SettingsUi.Interface.cs
@@ -207,12 +207,18 @@ public partial class SettingsUi
             _uiShared.DrawHelpText("Delay until the profile should be displayed");
             if (!showProfiles) ImGui.EndDisabled();
         }
-        if (ImGui.Checkbox("Show profiles marked as NSFW", ref showNsfwProfiles))
+        using (ImRaii.Disabled(!UiSharedService.CtrlPressed() && !showNsfwProfiles))
         {
-            Mediator.Publish(new ClearProfileDataMessage());
-            _configService.Current.ProfilesAllowNsfw = showNsfwProfiles;
-            _configService.Save();
+            if (ImGui.Checkbox("Show profiles marked as NSFW", ref showNsfwProfiles))
+            {
+                Mediator.Publish(new ClearProfileDataMessage());
+                _configService.Current.ProfilesAllowNsfw = showNsfwProfiles;
+                _configService.Save();
+            }
         }
+        UiSharedService.AttachToolTip("You should NOT enable this feature if you are under 18 and/or uncomfortable with NSFW content." + Environment.NewLine
+            + "Furthermore you understand only illegal NSFW content, or content breaking PlayerSync rules, is reportable for ToS abuse."
+            + UiSharedService.TooltipSeparator + "Hold CTRL to confirm you understand.");
         _uiShared.DrawHelpText("Will show profiles that have the NSFW tag enabled");
         using (ImRaii.Disabled(!showNsfwProfiles))
         {

--- a/PlayerSync/UI/SettingsUi.Service.cs
+++ b/PlayerSync/UI/SettingsUi.Service.cs
@@ -135,6 +135,8 @@ public partial class SettingsUi
         _uiShared.BigText("Service");
         ImGuiHelpers.ScaledDummy(2);
         var useBackupServer = _serverConfigurationManager.EnableBackupServer;
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudRed, "Only use the Proxied Server option if the PlayerSync Support Team has advised it, " +
+            "or if you are experiencing persistent connection issues that normal troubleshooting hasn't resolved.");
         if (ImGui.Checkbox("Use Proxied Server", ref useBackupServer))
         {
             _serverConfigurationManager.EnableBackupServer = useBackupServer;

--- a/PlayerSync/UI/SettingsUi.Service.cs
+++ b/PlayerSync/UI/SettingsUi.Service.cs
@@ -55,22 +55,6 @@ public partial class SettingsUi
     private Task<(bool Success, bool PartialSuccess, string Result)>? _secretKeysConversionTask = null;
     private CancellationTokenSource _secretKeysConversionCts = new CancellationTokenSource();
     private ServerStorage _selectedServer = null;
-    private Task<AccountInfoDto>? _retrieveAccountInfoTask;
-    private AccountInfoDto? _accountInfo;
-
-    private string _selectedAliasText = "";
-    private string _selectedAliasCurrent = "";
-    private Task<(bool ok, string msg)>? _uidUpdateTask;
-    private (bool ok, string msg)? _uidResult;
-
-    private GroupData? _selectedSyncshell;
-    private string _selectedSyncshellAliasText = "";
-    private string _selectedSyncshellAliasCurrent = "";
-    private Task<(bool ok, string msg)>? _groupUpdateTask;
-    private (bool ok, string msg)? _groupResult;
-    private string? _selectedUid;
-    private string? _selectedSyncshellGid;
-    private int _currentServer = -1;
 
     private async Task<(bool Success, bool partialSuccess, string Result)> ConvertSecretKeysToUIDs(ServerStorage serverStorage, CancellationToken token)
     {

--- a/PlayerSync/UI/SettingsUi.Vanity.cs
+++ b/PlayerSync/UI/SettingsUi.Vanity.cs
@@ -4,6 +4,7 @@ using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using MareSynchronos.API.Data;
 using MareSynchronos.API.Data.Validators;
+using MareSynchronos.API.Dto;
 using MareSynchronos.MareConfiguration.Configurations;
 using MareSynchronos.UI.ModernUi;
 using System.Numerics;
@@ -13,6 +14,23 @@ namespace MareSynchronos.UI;
 
 public partial class SettingsUi
 {
+    private Task<AccountInfoDto>? _retrieveAccountInfoTask;
+    private AccountInfoDto? _accountInfo;
+
+    private string _selectedAliasText = "";
+    private string _selectedAliasCurrent = "";
+    private Task<(bool ok, string msg)>? _uidUpdateTask;
+    private (bool ok, string msg)? _uidResult;
+
+    private GroupData? _selectedSyncshell;
+    private string _selectedSyncshellAliasText = "";
+    private string _selectedSyncshellAliasCurrent = "";
+    private Task<(bool ok, string msg)>? _groupUpdateTask;
+    private (bool ok, string msg)? _groupResult;
+    private string? _selectedUid;
+    private string? _selectedSyncshellGid;
+    private int _currentServer = -1;
+
     private UiNav.Tab<VanityTabs>? _selectedTabVanity;
 
     private IReadOnlyList<UiNav.Tab<VanityTabs>>? _vanityTabs;

--- a/PlayerSync/UI/SettingsUi.cs
+++ b/PlayerSync/UI/SettingsUi.cs
@@ -121,6 +121,11 @@ public partial class SettingsUi : WindowMediatorSubscriberBase
         Mediator.Subscribe<CharacterDataCreatedMessage>(this, (msg) => LastCreatedCharacterData = msg.CharacterData);
         Mediator.Subscribe<DownloadStartedMessage>(this, (msg) => _currentDownloads[msg.DownloadId] = msg.DownloadStatus);
         Mediator.Subscribe<DownloadFinishedMessage>(this, (msg) => _currentDownloads.TryRemove(msg.DownloadId, out _));
+        Mediator.Subscribe<ConnectedMessage>(this, (_) =>
+        {
+            _accountInfo = null;
+            _retrieveAccountInfoTask = null;
+        });
     }
 
     public CharacterData? LastCreatedCharacterData { private get; set; }

--- a/PlayerSync/UI/SyncshellAdminUI.cs
+++ b/PlayerSync/UI/SyncshellAdminUI.cs
@@ -320,6 +320,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         _selectedTabSyncshellAdmin.TabAction.Invoke();
     }
 
+    private string _filterText = string.Empty;
     private void DrawUserList()
     {
         if (!_pairManager.GroupPairs.TryGetValue(GroupFullInfo, out var pairs))
@@ -328,6 +329,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         }
         else
         {
+            ImGui.InputText("Filter##userfilter", ref _filterText, 32);
             using var table = ImRaii.Table("userList#" + GroupFullInfo.Group.GID, 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.ScrollY);
             if (table)
             {
@@ -337,7 +339,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
                 ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.None, 2);
                 ImGui.TableHeadersRow();
 
-                var groupedPairs = new Dictionary<Pair, GroupPairUserInfo?>(pairs.Select(p => new KeyValuePair<Pair, GroupPairUserInfo?>(p,
+                var groupedPairs = new Dictionary<Pair, GroupPairUserInfo?>(pairs.Where(p => p.UserData.UID.Contains(_filterText) || (p.UserData.Alias?.Contains(_filterText) ?? false)).Select(p => new KeyValuePair<Pair, GroupPairUserInfo?>(p,
                     GroupFullInfo.GroupPairUserInfos.TryGetValue(p.UserData.UID, out GroupPairUserInfo value) ? value : null)));
 
                 foreach (var pair in groupedPairs.OrderBy(p =>

--- a/PlayerSync/UI/SyncshellAdminUI.cs
+++ b/PlayerSync/UI/SyncshellAdminUI.cs
@@ -329,7 +329,9 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         }
         else
         {
-            ImGui.InputText("Filter##userfilter", ref _filterText, 32);
+            ImGui.SetNextItemWidth(280f * ImGuiHelpers.GlobalScale);
+            ImGui.InputText("Filter##userfilter", ref _filterText, 20);
+            ImGuiHelpers.ScaledDummy(2);
             using var table = ImRaii.Table("userList#" + GroupFullInfo.Group.GID, 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.ScrollY);
             if (table)
             {

--- a/PlayerSync/UI/SyncshellAdminUI.cs
+++ b/PlayerSync/UI/SyncshellAdminUI.cs
@@ -321,147 +321,176 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
     }
 
     private string _filterText = string.Empty;
-    private void DrawUserList()
+    private unsafe void DrawUserList()
     {
         if (!_pairManager.GroupPairs.TryGetValue(GroupFullInfo, out var pairs))
         {
             UiSharedService.ColorTextWrapped("No users found in this Syncshell", ImGuiColors.DalamudYellow);
+            return;
         }
-        else
-        {
-            ImGui.SetNextItemWidth(280f * ImGuiHelpers.GlobalScale);
-            ImGui.InputText("Filter##userfilter", ref _filterText, 20);
-            ImGuiHelpers.ScaledDummy(2);
-            using var table = ImRaii.Table("userList#" + GroupFullInfo.Group.GID, 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.ScrollY);
-            if (table)
+
+        ImGui.SetNextItemWidth(280f * ImGuiHelpers.GlobalScale);
+        ImGui.InputText("Filter##userfilter", ref _filterText, 20);
+        ImGuiHelpers.ScaledDummy(2);
+
+        using var table = ImRaii.Table(
+            "userList#" + GroupFullInfo.Group.GID,
+            4,
+            ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.ScrollY);
+
+        if (!table)
+            return;
+
+        ImGui.TableSetupColumn("Alias/UID/Note", ImGuiTableColumnFlags.None, 2);
+        ImGui.TableSetupColumn("Online/Name", ImGuiTableColumnFlags.None, 2);
+        ImGui.TableSetupColumn("Flags", ImGuiTableColumnFlags.None, 1);
+        ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.None, 2);
+        ImGui.TableHeadersRow();
+
+        var groupedPairs = pairs
+            .Where(pair =>
+                string.IsNullOrEmpty(_filterText)
+                || pair.UserData.UID.Contains(_filterText, StringComparison.OrdinalIgnoreCase)
+                || (pair.UserData.Alias?.Contains(_filterText, StringComparison.OrdinalIgnoreCase) ?? false))
+            .Select(pair => new
             {
-                ImGui.TableSetupColumn("Alias/UID/Note", ImGuiTableColumnFlags.None, 2);
-                ImGui.TableSetupColumn("Online/Name", ImGuiTableColumnFlags.None, 2);
-                ImGui.TableSetupColumn("Flags", ImGuiTableColumnFlags.None, 1);
-                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.None, 2);
-                ImGui.TableHeadersRow();
+                Pair = pair,
+                Info = GroupFullInfo.GroupPairUserInfos.TryGetValue(pair.UserData.UID, out GroupPairUserInfo value)
+                    ? (GroupPairUserInfo?)value
+                    : null
+            })
+            .OrderBy(pairInfo =>
+            {
+                if (pairInfo.Info == null) return 10;
+                if (pairInfo.Info.Value.IsModerator()) return 1;
+                if (pairInfo.Info.Value.IsPinned()) return 2;
+                if (pairInfo.Info.Value.IsGuest()) return 0;
+                return 10;
+            })
+            .ThenBy(pairInfo => pairInfo.Pair.GetNote() ?? pairInfo.Pair.UserData.AliasOrUID, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
-                var groupedPairs = new Dictionary<Pair, GroupPairUserInfo?>(pairs.Where(p => p.UserData.UID.Contains(_filterText) || (p.UserData.Alias?.Contains(_filterText) ?? false)).Select(p => new KeyValuePair<Pair, GroupPairUserInfo?>(p,
-                    GroupFullInfo.GroupPairUserInfos.TryGetValue(p.UserData.UID, out GroupPairUserInfo value) ? value : null)));
+        var rowHeight = ImGui.GetTextLineHeightWithSpacing() + (ImGui.GetStyle().CellPadding.Y * 2f);
 
-                foreach (var pair in groupedPairs.OrderBy(p =>
+        ImGuiListClipper clipper = new();
+        clipper.Begin(groupedPairs.Count, rowHeight);
+
+        while (clipper.Step())
+        {
+            for (int itemIndex = clipper.DisplayStart; itemIndex < clipper.DisplayEnd; itemIndex++)
+            {
+                var pair = groupedPairs[itemIndex];
+
+                ImGui.TableNextRow(ImGuiTableRowFlags.None, rowHeight);
+
+                using var tableId = ImRaii.PushId("userTable_" + pair.Pair.UserData.UID);
+
+                ImGui.TableNextColumn(); // alias/uid/note
+                var note = pair.Pair.GetNote();
+                var text = note == null
+                    ? pair.Pair.UserData.AliasOrUID
+                    : note + " (" + pair.Pair.UserData.AliasOrUID + ")";
+                ImGui.AlignTextToFramePadding();
+                ImGui.TextUnformatted(text);
+
+                ImGui.TableNextColumn(); // online/name
+                string onlineText = pair.Pair.IsOnline ? "Online" : "Offline";
+                if (!string.IsNullOrEmpty(pair.Pair.PlayerName))
                 {
-                    if (p.Value == null) return 10;
-                    if (p.Value.Value.IsModerator()) return 1;
-                    if (p.Value.Value.IsPinned()) return 2;
-                    if (p.Value.Value.IsGuest()) return 0;
-                    return 10;
-                }).ThenBy(p => p.Key.GetNote() ?? p.Key.UserData.AliasOrUID, StringComparer.OrdinalIgnoreCase))
+                    onlineText += " (" + pair.Pair.PlayerName + ")";
+                }
+                var boolcolor = UiSharedService.GetBoolColor(pair.Pair.IsOnline);
+                ImGui.AlignTextToFramePadding();
+                UiSharedService.ColorText(onlineText, boolcolor);
+
+                ImGui.TableNextColumn(); // special flags
+                if (pair.Info != null && (pair.Info.Value.IsModerator() || pair.Info.Value.IsPinned() || pair.Info.Value.IsGuest()))
                 {
-                    using var tableId = ImRaii.PushId("userTable_" + pair.Key.UserData.UID);
-
-                    ImGui.TableNextColumn(); // alias/uid/note
-                    var note = pair.Key.GetNote();
-                    var text = note == null ? pair.Key.UserData.AliasOrUID : note + " (" + pair.Key.UserData.AliasOrUID + ")";
-                    ImGui.AlignTextToFramePadding();
-                    ImGui.TextUnformatted(text);
-
-                    ImGui.TableNextColumn(); // online/name
-                    string onlineText = pair.Key.IsOnline ? "Online" : "Offline";
-                    if (!string.IsNullOrEmpty(pair.Key.PlayerName))
+                    if (pair.Info.Value.IsModerator())
                     {
-                        onlineText += " (" + pair.Key.PlayerName + ")";
+                        _uiSharedService.IconText(FontAwesomeIcon.UserShield);
+                        UiSharedService.AttachToolTip("Moderator");
+                        if (pair.Info.Value.IsGuest()) ImGui.SameLine();
                     }
-                    var boolcolor = UiSharedService.GetBoolColor(pair.Key.IsOnline);
-                    ImGui.AlignTextToFramePadding();
-                    UiSharedService.ColorText(onlineText, boolcolor);
-
-                    ImGui.TableNextColumn(); // special flags
-                    if (pair.Value != null && (pair.Value.Value.IsModerator() || pair.Value.Value.IsPinned() || pair.Value.Value.IsGuest()))
+                    if (pair.Info.Value.IsPinned())
                     {
-                        if (pair.Value.Value.IsModerator())
-                        {
-                            _uiSharedService.IconText(FontAwesomeIcon.UserShield);
-                            UiSharedService.AttachToolTip("Moderator");
-                            if (pair.Value.Value.IsGuest()) ImGui.SameLine();
-                        }
-                        if (pair.Value.Value.IsPinned())
-                        {
-                            _uiSharedService.IconText(FontAwesomeIcon.Thumbtack);
-                            UiSharedService.AttachToolTip("Pinned");
-                            if (pair.Value.Value.IsGuest()) ImGui.SameLine();
-                        }
-                        if (pair.Value.Value.IsGuest())
-                        {
-                            _uiSharedService.IconText(FontAwesomeIcon.PersonWalkingLuggage);
-                            UiSharedService.AttachToolTip("Guest");
-                        }
+                        _uiSharedService.IconText(FontAwesomeIcon.Thumbtack);
+                        UiSharedService.AttachToolTip("Pinned");
+                        if (pair.Info.Value.IsGuest()) ImGui.SameLine();
                     }
-                    else
+                    if (pair.Info.Value.IsGuest())
                     {
-                        _uiSharedService.IconText(FontAwesomeIcon.None);
+                        _uiSharedService.IconText(FontAwesomeIcon.PersonWalkingLuggage);
+                        UiSharedService.AttachToolTip("Guest");
                     }
+                }
+                else
+                {
+                    _uiSharedService.IconText(FontAwesomeIcon.None);
+                }
 
-                    ImGui.TableNextColumn(); // actions
-                    if (_isOwner)
+                ImGui.TableNextColumn(); // actions
+                if (_isOwner)
+                {
+                    if (_uiSharedService.IconButton(FontAwesomeIcon.UserShield))
                     {
-                        if (_uiSharedService.IconButton(FontAwesomeIcon.UserShield))
-                        {
-                            GroupPairUserInfo userInfo = pair.Value ?? GroupPairUserInfo.None;
-
-                            userInfo.SetModerator(!userInfo.IsModerator());
-
-                            _ = _apiController.GroupSetUserInfo(new GroupPairUserInfoDto(GroupFullInfo.Group, pair.Key.UserData, userInfo));
-                        }
-                        UiSharedService.AttachToolTip(pair.Value != null && pair.Value.Value.IsModerator() ? "Demod user" : "Mod user");
-                        ImGui.SameLine();
+                        GroupPairUserInfo userInfo = pair.Info ?? GroupPairUserInfo.None;
+                        userInfo.SetModerator(!userInfo.IsModerator());
+                        _ = _apiController.GroupSetUserInfo(new GroupPairUserInfoDto(GroupFullInfo.Group, pair.Pair.UserData, userInfo));
                     }
+                    UiSharedService.AttachToolTip(pair.Info != null && pair.Info.Value.IsModerator() ? "Demod user" : "Mod user");
+                    ImGui.SameLine();
+                }
 
-                    if (_isOwner || (pair.Value == null || (pair.Value != null && !pair.Value.Value.IsModerator())))
+                if (_isOwner || (pair.Info == null || !pair.Info.Value.IsModerator()))
+                {
+                    if (_uiSharedService.IconButton(FontAwesomeIcon.Thumbtack))
                     {
-                        if (_uiSharedService.IconButton(FontAwesomeIcon.Thumbtack))
-                        {
-                            GroupPairUserInfo userInfo = pair.Value ?? GroupPairUserInfo.None;
-
-                            userInfo.SetPinned(!userInfo.IsPinned());
-
-                            _ = _apiController.GroupSetUserInfo(new GroupPairUserInfoDto(GroupFullInfo.Group, pair.Key.UserData, userInfo));
-                        }
-                        UiSharedService.AttachToolTip(pair.Value != null && pair.Value.Value.IsPinned() ? "Unpin user" : "Pin user");
-                        ImGui.SameLine();
-
-                        bool isGuest = pair.Value?.IsGuest() ?? false;
-                        using (ImRaii.Disabled(!isGuest))
-                        {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.HouseMedicalCircleCheck))
-                            {
-                                GroupPairUserInfo userInfo = pair.Value ?? GroupPairUserInfo.None;
-                                userInfo.SetGuest(true);
-                                _ = _apiController.GroupSetUserInfo(new GroupPairUserInfoDto(GroupFullInfo.Group, pair.Key.UserData, userInfo));
-                            }
-                        }
-                        UiSharedService.AttachToolTip("Remove Guest status from user");
-                        ImGui.SameLine();
-
-                        using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
-                        {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.Trash))
-                            {
-                                _ = _apiController.GroupRemoveUser(new GroupPairDto(GroupFullInfo.Group, pair.Key.UserData));
-                            }
-                        }
-                        UiSharedService.AttachToolTip("Remove user from Syncshell"
-                            + UiSharedService.TooltipSeparator + "Hold CTRL to enable this button");
-
-                        ImGui.SameLine();
-                        using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
-                        {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.Ban))
-                            {
-                                Mediator.Publish(new OpenBanUserPopupMessage(pair.Key, GroupFullInfo));
-                            }
-                        }
-                        UiSharedService.AttachToolTip("Ban user from Syncshell"
-                            + UiSharedService.TooltipSeparator + "Hold CTRL to enable this button");
+                        GroupPairUserInfo userInfo = pair.Info ?? GroupPairUserInfo.None;
+                        userInfo.SetPinned(!userInfo.IsPinned());
+                        _ = _apiController.GroupSetUserInfo(new GroupPairUserInfoDto(GroupFullInfo.Group, pair.Pair.UserData, userInfo));
                     }
+                    UiSharedService.AttachToolTip(pair.Info != null && pair.Info.Value.IsPinned() ? "Unpin user" : "Pin user");
+                    ImGui.SameLine();
+
+                    bool isGuest = pair.Info?.IsGuest() ?? false;
+                    using (ImRaii.Disabled(!isGuest))
+                    {
+                        if (_uiSharedService.IconButton(FontAwesomeIcon.HouseMedicalCircleCheck))
+                        {
+                            GroupPairUserInfo userInfo = pair.Info ?? GroupPairUserInfo.None;
+                            userInfo.SetGuest(true);
+                            _ = _apiController.GroupSetUserInfo(new GroupPairUserInfoDto(GroupFullInfo.Group, pair.Pair.UserData, userInfo));
+                        }
+                    }
+                    UiSharedService.AttachToolTip("Remove Guest status from user");
+                    ImGui.SameLine();
+
+                    using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
+                    {
+                        if (_uiSharedService.IconButton(FontAwesomeIcon.Trash))
+                        {
+                            _ = _apiController.GroupRemoveUser(new GroupPairDto(GroupFullInfo.Group, pair.Pair.UserData));
+                        }
+                    }
+                    UiSharedService.AttachToolTip("Remove user from Syncshell"
+                        + UiSharedService.TooltipSeparator + "Hold CTRL to enable this button");
+
+                    ImGui.SameLine();
+                    using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
+                    {
+                        if (_uiSharedService.IconButton(FontAwesomeIcon.Ban))
+                        {
+                            Mediator.Publish(new OpenBanUserPopupMessage(pair.Pair, GroupFullInfo));
+                        }
+                    }
+                    UiSharedService.AttachToolTip("Ban user from Syncshell"
+                        + UiSharedService.TooltipSeparator + "Hold CTRL to enable this button");
                 }
             }
         }
+
+        clipper.End();
     }
 
     private void DrawCleanup()

--- a/PlayerSync/UI/SyncshellAdminUI.cs
+++ b/PlayerSync/UI/SyncshellAdminUI.cs
@@ -40,6 +40,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
     private readonly UiTheme _theme;
     private UiNav.NavItem<SyncshellAdminNav>? _selectedNavItem;
     private readonly IReadOnlyList<(string GroupLabel, IReadOnlyList<UiNav.NavItem<SyncshellAdminNav>> Items)> _navGroups;
+    private string _filterText = string.Empty;
 
     public SyncshellAdminUI(ILogger<SyncshellAdminUI> logger, MareMediator mediator, ApiController apiController, UiSharedService uiSharedService, 
         IBroadcastManager broadcastManager, PairManager pairManager, GroupFullInfoDto groupFullInfo, PerformanceCollectorService performanceCollectorService, UiTheme theme)
@@ -58,16 +59,21 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         _pwChangeSuccess = true;
         IsOpen = true;
         _isProfileSaved = true;
+
         SizeConstraints = new WindowSizeConstraints()
         {
             MinimumSize = new(1020, 700),
-            MaximumSize = new(1020, 2000),
+            MaximumSize = new(1020, 700),
         };
+
+        Flags = ImGuiWindowFlags.NoResize;
+
         Mediator.Subscribe<GroupInfoChanged>(this, message =>
         {
             Encoding.UTF8.GetBytes(message.GroupInfo.PublicData.GroupProfile?.Description ?? "", _descriptionBuffer.Span);
             Encoding.UTF8.GetBytes(message.GroupInfo.PublicData.GroupProfile?.Rules ?? "", _rulesBuffer.Span);
         });
+
         Encoding.UTF8.GetBytes(GroupFullInfo.PublicData.GroupProfile?.Description ?? "", _descriptionBuffer.Span);
         Encoding.UTF8.GetBytes(GroupFullInfo.PublicData.GroupProfile?.Rules ?? "", _rulesBuffer.Span);
 
@@ -320,7 +326,6 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         _selectedTabSyncshellAdmin.TabAction.Invoke();
     }
 
-    private string _filterText = string.Empty;
     private unsafe void DrawUserList()
     {
         if (!_pairManager.GroupPairs.TryGetValue(GroupFullInfo, out var pairs))
@@ -333,10 +338,8 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         ImGui.InputText("Filter##userfilter", ref _filterText, 20);
         ImGuiHelpers.ScaledDummy(2);
 
-        using var table = ImRaii.Table(
-            "userList#" + GroupFullInfo.Group.GID,
-            4,
-            ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.ScrollY);
+        var tableSize = new Vector2(0f, ImGui.GetContentRegionAvail().Y);
+        using var table = ImRaii.Table("userList#" + GroupFullInfo.Group.GID, 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.ScrollY, tableSize);
 
         if (!table)
             return;
@@ -345,6 +348,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         ImGui.TableSetupColumn("Online/Name", ImGuiTableColumnFlags.None, 2);
         ImGui.TableSetupColumn("Flags", ImGuiTableColumnFlags.None, 1);
         ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.None, 2);
+        ImGui.TableSetupScrollFreeze(0, 1);
         ImGui.TableHeadersRow();
 
         var groupedPairs = pairs
@@ -370,7 +374,8 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
             .ThenBy(pairInfo => pairInfo.Pair.GetNote() ?? pairInfo.Pair.UserData.AliasOrUID, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        var rowHeight = ImGui.GetTextLineHeightWithSpacing() + (ImGui.GetStyle().CellPadding.Y * 2f);
+        var style = ImGui.GetStyle();
+        var rowHeight = MathF.Max(ImGui.GetTextLineHeight(), ImGui.GetFrameHeight()) + (style.CellPadding.Y * 2f) + 1f;
 
         ImGuiListClipper clipper = new();
         clipper.Begin(groupedPairs.Count, rowHeight);
@@ -381,7 +386,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
             {
                 var pair = groupedPairs[itemIndex];
 
-                ImGui.TableNextRow(ImGuiTableRowFlags.None, rowHeight);
+                ImGui.TableNextRow();
 
                 using var tableId = ImRaii.PushId("userTable_" + pair.Pair.UserData.UID);
 

--- a/PlayerSync/WebAPI/SignalR/ApiController.Functions.Callbacks.cs
+++ b/PlayerSync/WebAPI/SignalR/ApiController.Functions.Callbacks.cs
@@ -199,7 +199,7 @@ public partial class ApiController
     public Task Client_UserUpdateProfile(UserDto dto)
     {
         Logger.LogDebug("Client_UserUpdateProfile: {dto}", dto);
-        ExecuteSafely(() => Mediator.Publish(new ClearProfileDataMessage(dto.User)));
+        ExecuteSafely(() => Mediator.Publish(new ClearProfileDataMessage(dto.User, true)));
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
- Add Setup Guide button to the install wizard
- Reset Vanity/Alias UI info on reconnect
- Fix Vanity/Alias from Secondary UID
- Several minor UI tweaks
- Add search box to Syncshell Admin Panel
- Add culling to Syncshell Admin Panel to help with FPS of long player lists
- Add warning label when enabling NSFW profiles to be viewed
- Fix Player Analysis Viewer highlighting wrong user UIDs when not set to "Live"