### PR TITLE
Logic update for ZoneSync

### DIFF
--- a/PlayerSync/PlayerData/Pairs/GroupZoneSyncManager.cs
+++ b/PlayerSync/PlayerData/Pairs/GroupZoneSyncManager.cs
@@ -151,12 +151,11 @@ public class GroupZoneSyncManager : DisposableMediatorSubscriberBase, IHostedSer
         _logger.LogTrace("ZoneSync: DataCenter={instdata} ServerID={serverId} Instance={instance} RoomID={roomId}", 
             datacenter, ownLocation.ServerId, instance, ownLocation.RoomId);
         
-        //Set ServerId to datacenter and RoomId to instance if instanceBound
-        if (instanceBound && instance > 0)
-        {
+        //Sets Zonesync ServerId and RoomId to instance and datacenter depending on content and openworld instanced zones 
+        if (instance > 0 || instanceBound)
             ownLocation.RoomId = instance;
+        if (instanceBound)
             ownLocation.ServerId = datacenter!.Value;
-        }
         
         var isResidential = ownLocation.WardId != 0;
         var isTown = TerritoryTools.TerritoryStaticMap.IsTown(ownLocation.TerritoryId);


### PR DESCRIPTION
This will set RoomId to the InstanceId if you are either in content (boundbyduty), or if the openworld zone instance is greater than 0 (default if they are not instanced is 0). This means zones like Middle La Noscea if they have an instance 1 instance 2 etc this will catch it.

This also sets the ServerId to the DatacenterId if you are in content