### PR TITLE
PSync 1.15.2.2

### DIFF
--- a/PlayerSync/MareConfiguration/Configurations/MareConfig.cs
+++ b/PlayerSync/MareConfiguration/Configurations/MareConfig.cs
@@ -110,6 +110,7 @@ public class MareConfig : IMareConfiguration
     };
     public bool[] SPriority { get; set; } = new bool[5];
     public bool ShowProfileIconByNames { get; set; } = true;
+    public bool SoftTargetPairsOnHover { get; set; } = false;
     public bool EnableValidationChecks { get; set; } = true;
     public bool EnableColorWaveNotification { get; set; } = true;
     public NotificationLocation PairRequestNotification { get; set; } = NotificationLocation.Both;

--- a/PlayerSync/MareConfiguration/Configurations/MareConfig.cs
+++ b/PlayerSync/MareConfiguration/Configurations/MareConfig.cs
@@ -106,7 +106,7 @@ public class MareConfig : IMareConfiguration
         ContextMenuItemId.PairData,
         ContextMenuItemId.InviteToSyncshell,
         ContextMenuItemId.AddToOverrides,
-        ContextMenuItemId.PauseForever
+        ContextMenuItemId.PausePair
     };
     public bool[] SPriority { get; set; } = new bool[5];
     public bool ShowProfileIconByNames { get; set; } = true;

--- a/PlayerSync/MareConfiguration/Configurations/PlayerPerformanceConfig.cs
+++ b/PlayerSync/MareConfiguration/Configurations/PlayerPerformanceConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace MareSynchronos.MareConfiguration.Configurations;
+﻿using MareSynchronos.MareConfiguration.Models;
+
+namespace MareSynchronos.MareConfiguration.Configurations;
 
 /// <summary>
 /// The policy for when to use server-compressed alternate files when available.
@@ -56,6 +58,8 @@ public class PlayerPerformanceConfig : IMareConfiguration
     public int MaxHeightAbsolute { get; set; } = 366;
     public List<string> UIDsToIgnoreForHeightPausing { get; set; } = new();
     public List<string> UIDsToOverride { get; set; } = new();
+    public PauseDuration PauseDurationAutoPauseExceedingThresholds { get; set; } = PauseDuration.Indefinitely;
+    public PauseDuration PauseDurationAutoPauseExceedingHeightThresholds { get; set; } = PauseDuration.Indefinitely;
 }
 
 public static class PlayerPerformanceConfigExtensions

--- a/PlayerSync/MareConfiguration/Configurations/ZoneSyncConfig.cs
+++ b/PlayerSync/MareConfiguration/Configurations/ZoneSyncConfig.cs
@@ -15,4 +15,7 @@ public class ZoneSyncConfig : IMareConfiguration
     public bool EnablePvpSync { get; set; } = true;
     public int ZoneJoinDelayTime { get; set; } = 10;
     public Dictionary<string, bool> ZoneSyncEnabledPerCharacter { get; set; } = new(StringComparer.Ordinal);
+    public bool ZoneSyncFilterAnimations { get; set; } = false;
+    public bool ZoneSyncFilterSounds { get; set; } = false;
+    public bool ZoneSyncFilterVfx { get; set; } = false;
 }

--- a/PlayerSync/MareConfiguration/Models/PauseDuration.cs
+++ b/PlayerSync/MareConfiguration/Models/PauseDuration.cs
@@ -1,0 +1,9 @@
+﻿namespace MareSynchronos.MareConfiguration.Models;
+
+public enum PauseDuration
+{
+    Indefinitely = -1,
+    ThirtyMinutes = 30,
+    FourHours = 240,
+    EightHours = 480
+}

--- a/PlayerSync/MareConfiguration/Models/ServerNotesStorage.cs
+++ b/PlayerSync/MareConfiguration/Models/ServerNotesStorage.cs
@@ -7,5 +7,6 @@ public class ServerNotesStorage
     public Dictionary<string, string> UidServerProfileNotes { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, PauseReason> PausedUids { get; set; } = new(StringComparer.Ordinal);
     public List<string> PairingBlacklistUids { get; set; } = new();
-    public Dictionary<string, string> PendingRequests{ get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, string> PendingRequests { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, DateTimeOffset> PendingPausedPairs { get; set; } = new (StringComparer.Ordinal);
 }

--- a/PlayerSync/PlayerData/Factories/PairFactory.cs
+++ b/PlayerSync/PlayerData/Factories/PairFactory.cs
@@ -15,25 +15,28 @@ public class PairFactory
     private readonly MareMediator _mareMediator;
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly MareConfigService _configService;
+    private readonly ZoneSyncConfigService _zoneSyncConfigService;
 
     public PairFactory(ILoggerFactory loggerFactory, PairHandlerFactory cachedPlayerFactory,
-        MareMediator mareMediator, ServerConfigurationManager serverConfigurationManager, MareConfigService mareConfigService)
+        MareMediator mareMediator, ServerConfigurationManager serverConfigurationManager, 
+        MareConfigService mareConfigService, ZoneSyncConfigService zoneSyncConfigService)
     {
         _loggerFactory = loggerFactory;
         _cachedPlayerFactory = cachedPlayerFactory;
         _mareMediator = mareMediator;
         _serverConfigurationManager = serverConfigurationManager;
         _configService = mareConfigService;
+        _zoneSyncConfigService = zoneSyncConfigService;
     }
 
     public Pair Create(UserFullPairDto userPairDto)
     {
-        return new Pair(_loggerFactory.CreateLogger<Pair>(), userPairDto, _cachedPlayerFactory, _mareMediator, _serverConfigurationManager, _configService);
+        return new Pair(_loggerFactory.CreateLogger<Pair>(), userPairDto, _cachedPlayerFactory, _mareMediator, _serverConfigurationManager, _configService, _zoneSyncConfigService);
     }
 
     public Pair Create(UserPairDto userPairDto)
     {
         return new Pair(_loggerFactory.CreateLogger<Pair>(), new(userPairDto.User, userPairDto.IndividualPairStatus, [], userPairDto.OwnPermissions, userPairDto.OtherPermissions),
-            _cachedPlayerFactory, _mareMediator, _serverConfigurationManager, _configService);
+            _cachedPlayerFactory, _mareMediator, _serverConfigurationManager, _configService, _zoneSyncConfigService);
     }
 }

--- a/PlayerSync/PlayerData/Handlers/PairContextMenuHandler.cs
+++ b/PlayerSync/PlayerData/Handlers/PairContextMenuHandler.cs
@@ -101,7 +101,8 @@ namespace MareSynchronos.PlayerData.Handlers
             if (string.Equals(args.AddonName, "ChatLog", StringComparison.OrdinalIgnoreCase))
                 AddUserPairChatContextMenu(args);
 
-            var target = _dalamudUtilService.TargetAddress;
+            var target = _dalamudUtilService.SoftTargetAddress != nint.Zero ? _dalamudUtilService.SoftTargetAddress : _dalamudUtilService.TargetAddress;
+            if (target == nint.Zero) return;
             var pairs = _pairManager.GetVisiblePairs();
             var currentTargetPair = pairs.SingleOrDefault(u => u.Address == target);
             if (currentTargetPair != null)

--- a/PlayerSync/PlayerData/Handlers/PairContextMenuHandler.cs
+++ b/PlayerSync/PlayerData/Handlers/PairContextMenuHandler.cs
@@ -398,8 +398,17 @@ namespace MareSynchronos.PlayerData.Handlers
 
             menuItems.Add(new MenuItem()
             {
+                Name = new SeStringBuilder().AddText("Pause").Build(),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.Indefinitely)),
+                UseDefaultPrefix = false,
+                PrefixChar = 'P',
+                PrefixColor = 17,
+            });
+
+            menuItems.Add(new MenuItem()
+            {
                 Name = new SeStringBuilder().AddText("Pause for 30 minutes").Build(),
-                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, MareConfiguration.Models.PauseReason.Manual, PauseDuration.ThirtyMinutes)),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.ThirtyMinutes)),
                 UseDefaultPrefix = false,
                 PrefixChar = 'P',
                 PrefixColor = 17,
@@ -408,7 +417,7 @@ namespace MareSynchronos.PlayerData.Handlers
             menuItems.Add(new MenuItem()
             {
                 Name = new SeStringBuilder().AddText("Pause for 4 hours").Build(),
-                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, MareConfiguration.Models.PauseReason.Manual, PauseDuration.FourHours)),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.FourHours)),
                 UseDefaultPrefix = false,
                 PrefixChar = 'P',
                 PrefixColor = 17,
@@ -417,7 +426,7 @@ namespace MareSynchronos.PlayerData.Handlers
             menuItems.Add(new MenuItem()
             {
                 Name = new SeStringBuilder().AddText("Pause for 8 hours").Build(),
-                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, MareConfiguration.Models.PauseReason.Manual, PauseDuration.EightHours)),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.EightHours)),
                 UseDefaultPrefix = false,
                 PrefixChar = 'P',
                 PrefixColor = 17,
@@ -425,7 +434,7 @@ namespace MareSynchronos.PlayerData.Handlers
 
             menuItems.Add(new MenuItem()
             {
-                Name = new SeStringBuilder().AddText("Keep Paused Forever").Build(),
+                Name = new SeStringBuilder().AddText("Block Pairing").Build(),
                 OnClicked = (a) => Mediator.Publish(new UserPairStickyPauseAndRemoveMessage(pair.UserData)),
                 UseDefaultPrefix = false,
                 PrefixChar = 'P',
@@ -439,7 +448,7 @@ namespace MareSynchronos.PlayerData.Handlers
                 OnClicked = _ => _dalamudUtilService.OpenContextMenu(clickedArgs.AgentPtr)
             });
 
-            clickedArgs.OpenSubmenu(new SeStringBuilder().AddText($"Pause {pair.UserData.AliasOrUID}").Build(), menuItems);
+            clickedArgs.OpenSubmenu(new SeStringBuilder().AddText($"Pair {pair.UserData.AliasOrUID}").Build(), menuItems);
         }
 
         private void AddUserPairChatContextMenu(IMenuOpenedArgs args)

--- a/PlayerSync/PlayerData/Handlers/PairContextMenuHandler.cs
+++ b/PlayerSync/PlayerData/Handlers/PairContextMenuHandler.cs
@@ -8,6 +8,7 @@ using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services;
 using MareSynchronos.Services.Mediator;
 using MareSynchronos.Services.ServerConfiguration;
+using MareSynchronos.MareConfiguration.Models;
 using MareSynchronos.Utils;
 using MareSynchronos.WebAPI;
 using Microsoft.Extensions.Hosting;
@@ -20,7 +21,7 @@ namespace MareSynchronos.PlayerData.Handlers
     {
         None = 0,
         OpenProfile,
-        PauseForever,
+        PausePair,
         PairData,
         InviteToSyncshell,
         AddToOverrides,
@@ -34,7 +35,7 @@ namespace MareSynchronos.PlayerData.Handlers
         public static ContextMenuItemId[] Order { get; set; } = new ContextMenuItemId[6]
         {
         ContextMenuItemId.OpenProfile,
-        ContextMenuItemId.PauseForever,
+        ContextMenuItemId.PausePair,
         ContextMenuItemId.PairData,
         ContextMenuItemId.InviteToSyncshell,
         ContextMenuItemId.AddToOverrides,
@@ -171,12 +172,12 @@ namespace MareSynchronos.PlayerData.Handlers
                         });
                         break;
 
-                    // This kind of acts like a blacklist feature
-                    case ContextMenuItemId.PauseForever:
+                    case ContextMenuItemId.PausePair:
                         args.AddMenuItem(new MenuItem()
                         {
-                            Name = new SeStringBuilder().AddText("Keep Paused").Build(),
-                            OnClicked = (a) => Mediator.Publish(new UserPairStickyPauseAndRemoveMessage(pair.UserData)),
+                            Name = new SeStringBuilder().AddText($"Pause {pair.UserData.AliasOrUID}").Build(),
+                            OnClicked = (args) => DrawPairPauseSubmenu(pair, args),
+                            IsSubmenu = true,
                             UseDefaultPrefix = false,
                             PrefixChar = 'P',
                             PrefixColor = 17,
@@ -389,6 +390,56 @@ namespace MareSynchronos.PlayerData.Handlers
             });
 
             clickedArgs.OpenSubmenu(new SeStringBuilder().AddText("Add to Overrides").Build(), menuItems);
+        }
+
+        private void DrawPairPauseSubmenu(Pair pair, IMenuItemClickedArgs clickedArgs)
+        {
+            var menuItems = new List<MenuItem>();
+
+            menuItems.Add(new MenuItem()
+            {
+                Name = new SeStringBuilder().AddText("Pause for 30 minutes").Build(),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, MareConfiguration.Models.PauseReason.Manual, PauseDuration.ThirtyMinutes)),
+                UseDefaultPrefix = false,
+                PrefixChar = 'P',
+                PrefixColor = 17,
+            });
+
+            menuItems.Add(new MenuItem()
+            {
+                Name = new SeStringBuilder().AddText("Pause for 4 hours").Build(),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, MareConfiguration.Models.PauseReason.Manual, PauseDuration.FourHours)),
+                UseDefaultPrefix = false,
+                PrefixChar = 'P',
+                PrefixColor = 17,
+            });
+
+            menuItems.Add(new MenuItem()
+            {
+                Name = new SeStringBuilder().AddText("Pause for 8 hours").Build(),
+                OnClicked = (a) => Mediator.Publish(new PauseMessage(pair.UserData, MareConfiguration.Models.PauseReason.Manual, PauseDuration.EightHours)),
+                UseDefaultPrefix = false,
+                PrefixChar = 'P',
+                PrefixColor = 17,
+            });
+
+            menuItems.Add(new MenuItem()
+            {
+                Name = new SeStringBuilder().AddText("Keep Paused Forever").Build(),
+                OnClicked = (a) => Mediator.Publish(new UserPairStickyPauseAndRemoveMessage(pair.UserData)),
+                UseDefaultPrefix = false,
+                PrefixChar = 'P',
+                PrefixColor = 17,
+            });
+
+            menuItems.Add(new MenuItem()
+            {
+                Name = new SeStringBuilder().AddText("Return").Build(),
+                IsReturn = true,
+                OnClicked = _ => _dalamudUtilService.OpenContextMenu(clickedArgs.AgentPtr)
+            });
+
+            clickedArgs.OpenSubmenu(new SeStringBuilder().AddText($"Pause {pair.UserData.AliasOrUID}").Build(), menuItems);
         }
 
         private void AddUserPairChatContextMenu(IMenuOpenedArgs args)

--- a/PlayerSync/PlayerData/Pairs/Pair.cs
+++ b/PlayerSync/PlayerData/Pairs/Pair.cs
@@ -20,18 +20,20 @@ public class Pair
     private readonly ILogger<Pair> _logger;
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly MareConfigService _configService;
+    private readonly ZoneSyncConfigService _zoneSyncConfig;
     private CancellationTokenSource _applicationCts = new();
     private OnlineUserIdentDto? _onlineUserIdentDto = null;
     private bool? _hasProfile = null;
 
     public Pair(ILogger<Pair> logger, UserFullPairDto userPair, PairHandlerFactory cachedPlayerFactory,
-        MareMediator mediator, ServerConfigurationManager serverConfigurationManager, MareConfigService mareConfigService)
+        MareMediator mediator, ServerConfigurationManager serverConfigurationManager, MareConfigService mareConfigService, ZoneSyncConfigService zoneSyncConfig)
     {
         _logger = logger;
         UserPair = userPair;
         _cachedPlayerFactory = cachedPlayerFactory;
         _serverConfigurationManager = serverConfigurationManager;
         _configService = mareConfigService;
+        _zoneSyncConfig = zoneSyncConfig;
     }
 
     public bool HasCachedPlayer => CachedPlayer != null && !string.IsNullOrEmpty(CachedPlayer.PlayerName) && _onlineUserIdentDto != null;
@@ -41,6 +43,7 @@ public class Pair
     public bool IsOnline => CachedPlayer != null;
 
     public bool IsPaired => IndividualPairStatus == IndividualPairStatus.Bidirectional || UserPair.Groups.Any();
+    public bool IsZoneSyncOnlyPair => IndividualPairStatus != IndividualPairStatus.Bidirectional && UserPair.Groups.All(g => g.StartsWith(Constants.GroupZoneSyncPrefix));
     public bool IsPaused => UserPair.OwnPermissions.IsPaused();
     public bool IsVisible => CachedPlayer?.IsVisible ?? false;
     public CharacterData? LastReceivedCharacterData { get; set; }
@@ -267,10 +270,12 @@ public class Pair
             return data;
         }
 
+        // permissions
         bool disableIndividualAnimations = UserPair.OtherPermissions.IsDisableAnimations() || UserPair.OwnPermissions.IsDisableAnimations();
         bool disableIndividualVFX = UserPair.OtherPermissions.IsDisableVFX() || UserPair.OwnPermissions.IsDisableVFX();
         bool disableIndividualSounds = UserPair.OtherPermissions.IsDisableSounds() || UserPair.OwnPermissions.IsDisableSounds();
 
+        // global filtering
         bool filterBiDiPairs = _configService.Current.DoFilteringBidirectionDirectPairs;
         bool isDirectPaired = UserPair.IndividualPairStatus == IndividualPairStatus.Bidirectional;
         bool overrideFilterPair = !filterBiDiPairs && isDirectPaired;
@@ -281,30 +286,37 @@ public class Pair
         _logger.LogTrace("Disable: Sounds: {disableIndividualSounds}, Anims: {disableIndividualAnims}; " +
             "VFX: {disableGroupSounds}", disableIndividualSounds, disableIndividualAnimations, disableIndividualVFX);
 
-        bool filterSounds = _configService.Current.FilterSounds;
+        // global filtering
         bool filterAnimations = _configService.Current.FilterAnimations;
+        bool filterSounds = _configService.Current.FilterSounds;
         bool filterVfx = _configService.Current.FilterVfx;
         bool filterMinionsMounts = _configService.Current.FilterMinionsAndMounts;
         bool filterPets = _configService.Current.FilterPets;
 
+        // zonesync filtering
+        bool filterZoneSyncAnimations = _zoneSyncConfig.Current.ZoneSyncFilterAnimations;
+        bool filterZoneSyncSounds = _zoneSyncConfig.Current.ZoneSyncFilterSounds;
+        bool filterZoneSyncVfx = _zoneSyncConfig.Current.ZoneSyncFilterVfx;
+
+        bool zoneSyncFiltering = IsZoneSyncOnlyPair && (filterZoneSyncAnimations || filterZoneSyncSounds || filterZoneSyncVfx);
         bool hasDisabledIndevidual = disableIndividualAnimations || disableIndividualSounds || disableIndividualVFX;
         bool hasDisabledViaFilter = filterAnimations || filterSounds || filterVfx || filterMinionsMounts || filterPets;
         bool filterUserPerms = hasDisabledViaFilter && !overrideFilterUid && !overrideFilterPair;
-        if (filterUserPerms || hasDisabledIndevidual)
+        if (filterUserPerms || hasDisabledIndevidual || zoneSyncFiltering)
         {
             _logger.LogTrace("Data cleaned up: Animations disabled: {disableAnimations}, Sounds disabled: {disableSounds}, VFX disabled: {disableVFX}",
                 disableIndividualAnimations, disableIndividualSounds, disableIndividualVFX);
             foreach (var objectKind in data.FileReplacements.Select(k => k.Key))
             {
-                if ((filterUserPerms && filterSounds) || disableIndividualSounds)
+                if ((filterUserPerms && filterSounds) || disableIndividualSounds || (zoneSyncFiltering && filterZoneSyncSounds))
                     data.FileReplacements[objectKind] = data.FileReplacements[objectKind]
                         .Where(f => !f.GamePaths.Any(p => p.EndsWith("scd", StringComparison.OrdinalIgnoreCase)))
                         .ToList();
-                if ((filterUserPerms && filterAnimations) || disableIndividualAnimations)
+                if ((filterUserPerms && filterAnimations) || disableIndividualAnimations || (zoneSyncFiltering && filterZoneSyncAnimations))
                     data.FileReplacements[objectKind] = data.FileReplacements[objectKind]
                         .Where(f => !f.GamePaths.Any(p => p.EndsWith("tmb", StringComparison.OrdinalIgnoreCase) || p.EndsWith("pap", StringComparison.OrdinalIgnoreCase)))
                         .ToList();
-                if ((filterUserPerms && filterVfx) || disableIndividualVFX)
+                if ((filterUserPerms && filterVfx) || disableIndividualVFX || (zoneSyncFiltering && filterZoneSyncVfx))
                     data.FileReplacements[objectKind] = data.FileReplacements[objectKind]
                         .Where(f => !f.GamePaths.Any(p => p.EndsWith("atex", StringComparison.OrdinalIgnoreCase) || p.EndsWith("avfx", StringComparison.OrdinalIgnoreCase)))
                         .ToList();

--- a/PlayerSync/PlayerData/Pairs/PairManager.cs
+++ b/PlayerSync/PlayerData/Pairs/PairManager.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud.Plugin.Services;
-using MareSynchronos.API.Data;
+﻿using MareSynchronos.API.Data;
 using MareSynchronos.API.Data.Comparer;
 using MareSynchronos.API.Data.Extensions;
 using MareSynchronos.API.Dto.Group;
@@ -18,6 +17,8 @@ namespace MareSynchronos.PlayerData.Pairs;
 
 public sealed class PairManager : DisposableMediatorSubscriberBase
 {
+    private readonly TimeSpan PausedPairCheckInterval = TimeSpan.FromMinutes(1);
+
     private readonly ConcurrentDictionary<UserData, Pair> _allClientPairs = new(UserDataComparer.Instance);
     private readonly ConcurrentDictionary<GroupData, GroupFullInfoDto> _allGroups = new(GroupDataComparer.Instance);
     private readonly MareConfigService _configurationService;
@@ -27,6 +28,9 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     private Lazy<Dictionary<GroupFullInfoDto, List<Pair>>> _groupPairsInternal;
     private Lazy<Dictionary<Pair, List<GroupFullInfoDto>>> _pairsWithGroupsInternal;
     private PairApplyQueue? _applyQueue = null;
+
+    private CancellationTokenSource? _periodicCts;
+    private Task? _periodicTask;
 
     public PairManager(ILogger<PairManager> logger, PairFactory pairFactory,
                 MareConfigService configurationService, ServerConfigurationManager serverConfigurationManager, MareMediator mediator)
@@ -44,6 +48,10 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
 
         if (_configurationService.Current.UseQueuedCharacterDataApplication)
             _applyQueue = new(_configurationService.Current.MaxConcurrentApplications);
+
+        _periodicCts?.Dispose();
+        _periodicCts = new CancellationTokenSource();
+        _periodicTask = PausedPairExpiredTimerCheckTask(_periodicCts.Token);
 
         Logger.LogTrace("{class} created.", nameof(PairManager));
     }
@@ -385,7 +393,10 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
         }
 
         if (pair.UserPair.OwnPermissions.IsPaused() && !dto.Permissions.IsPaused())
+        {
             _serverConfigurationManager.RemovePauseReasonForUid(pair.UserData.UID);
+            _serverConfigurationManager.RemovePendingPauseForUid(pair.UserData.UID);
+        }
 
         pair.UserPair.OwnPermissions = dto.Permissions;
 
@@ -445,6 +456,12 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
+
+        CancellationTokenSource? cts;
+        cts = _periodicCts;
+        _periodicCts = null;
+        cts?.Cancel();
+        cts?.Dispose();
 
         _applyQueue?.Dispose();
 
@@ -507,5 +524,81 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
         _groupPairsInternal = GroupPairsLazy();
         _pairsWithGroupsInternal = PairsWithGroupsLazy();
         Mediator.Publish(new RefreshUiMessage());
+    }
+
+    private async Task PausedPairExpiredTimerCheckTask(CancellationToken ct)
+    {
+        try
+        {
+            Logger.LogDebug("Starting checks for paused players to unpause.");
+            var initDelay = TimeSpan.FromMinutes(1);
+            await Task.Delay(initDelay, ct).ConfigureAwait(false); // init delay for plugin load
+
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    if (!_serverConfigurationManager.CurrentServer.FullPause)
+                    {
+                        Logger.LogTrace("Checking for paused pairs to unpause...");
+
+                        var onlinePairs = GetOnlineUserPairs();
+                        List<string> stalePausedEntries = new List<string>();
+
+                        var pendingPausedPairs = _serverConfigurationManager.GetPendingPausedPairUIDs();
+                        List<string> pairsToUnPause = new List<string>();
+
+                        foreach (var pausedPair in pendingPausedPairs)
+                        {
+                            var uid = pausedPair.Key;
+
+                            if (onlinePairs.Any(p => string.Equals(p.UserData.UID, uid, StringComparison.OrdinalIgnoreCase)))
+                            {
+                                stalePausedEntries.Add(uid);
+                                continue;
+                            }
+
+                            if (DateTimeOffset.UtcNow >= pausedPair.Value)
+                                pairsToUnPause.Add(uid);
+                        }
+
+                        foreach (var staleEntryUid in stalePausedEntries)
+                        {
+                            Logger.LogDebug("Removing stale paused pair entry for UID: {uid}", staleEntryUid);
+                            _serverConfigurationManager.RemovePauseReasonForUid(staleEntryUid);
+                            _serverConfigurationManager.RemovePendingPauseForUid(staleEntryUid);
+                        }
+
+                        foreach (var uidToUnpause in pairsToUnPause)
+                        {
+                            Logger.LogDebug("Automatically removing paused status for UID: {uid}", uidToUnpause);
+                            Mediator.Publish(new UnPauseMessage(new(uidToUnpause), true));
+                            await Task.Delay(250).ConfigureAwait(false);
+                        }
+                    }
+
+                    await Task.Delay(PausedPairCheckInterval, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // normal shutdown
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Error while checking for paused pair.");
+
+                    await Task.Delay(PausedPairCheckInterval, ct).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogCritical(ex, "Error while checking for paused pairs. This background task will now stop.");
+        }
+        finally
+        {
+            _periodicTask = null;
+        }
     }
 }

--- a/PlayerSync/PlayerSync.csproj
+++ b/PlayerSync/PlayerSync.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>1.15.2.1</Version>
+    <Version>1.15.2.2</Version>
     <Description></Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/MareSynchronos/client</PackageProjectUrl>

--- a/PlayerSync/Services/DalamudUtilService.cs
+++ b/PlayerSync/Services/DalamudUtilService.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud.Game.ClientState;
-using Dalamud.Game.ClientState.Conditions;
+﻿using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin.Services;
@@ -16,6 +15,7 @@ using MareSynchronos.Interop;
 using MareSynchronos.Interop.Ipc;
 using MareSynchronos.MareConfiguration;
 using MareSynchronos.PlayerData.Handlers;
+using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services.Mediator;
 using MareSynchronos.Utils;
 using Microsoft.Extensions.Hosting;
@@ -24,6 +24,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using GameObject = FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject;
+using TargetType = MareSynchronos.Services.Models.TargetType;
 
 namespace MareSynchronos.Services;
 
@@ -136,22 +137,9 @@ public class DalamudUtilService : IHostedService, IMediatorSubscriber
                 return (w, sb.ToString());
             });
         });
-        mediator.Subscribe<TargetPairMessage>(this, (msg) =>
-        {
-            if (clientState.IsPvP) return;
-            var name = msg.Pair.PlayerName;
-            if (string.IsNullOrEmpty(name)) return;
-            var addr = _playerCharas.FirstOrDefault(f => string.Equals(f.Value.Name, name, StringComparison.Ordinal)).Value.Address;
-            if (addr == nint.Zero) return;
-            var useFocusTarget = _configService.Current.UseFocusTarget;
-            _ = RunOnFrameworkThread(() =>
-            {
-                if (useFocusTarget)
-                    targetManager.FocusTarget = CreateGameObject(addr);
-                else
-                    targetManager.Target = CreateGameObject(addr);
-            }).ConfigureAwait(false);
-        });
+
+        mediator.Subscribe<TargetPairMessage>(this, (msg) => TargetPairByTargetType(msg.Pair, msg.TargetType));
+
         IsWine = Util.IsWine();
         _cid = RebuildCID();
     }
@@ -170,12 +158,6 @@ public class DalamudUtilService : IHostedService, IMediatorSubscriber
 
     public bool IsWine { get; init; }
 
-    public unsafe GameObject* GposeTarget
-    {
-        get => TargetSystem.Instance()->GPoseTarget;
-        set => TargetSystem.Instance()->GPoseTarget = value;
-    }
-
     public string TargetName
     {
         get => _targetManager.Target?.Name.TextValue ?? string.Empty;
@@ -184,7 +166,27 @@ public class DalamudUtilService : IHostedService, IMediatorSubscriber
     {
         get => _targetManager.Target?.Address ?? nint.Zero;
     }
-
+    public string SoftTargetName
+    {
+        get => _targetManager.SoftTarget?.Name.TextValue ?? string.Empty;
+    }
+    public unsafe nint SoftTargetAddress
+    {
+        get => _targetManager.SoftTarget?.Address ?? nint.Zero;
+    }
+    public string MouseOverTargetName
+    {
+        get => _targetManager.MouseOverTarget?.Name.TextValue ?? string.Empty;
+    }
+    public unsafe nint MouseOverTargetAddress
+    {
+        get => _targetManager.MouseOverTarget?.Address ?? nint.Zero;
+    }
+    public unsafe GameObject* GposeTarget
+    {
+        get => TargetSystem.Instance()->GPoseTarget;
+        set => TargetSystem.Instance()->GPoseTarget = value;
+    }
     private unsafe bool HasGposeTarget => GposeTarget != null;
     private unsafe int GPoseTargetIdx => !HasGposeTarget ? -1 : GposeTarget->ObjectIndex;
 
@@ -683,6 +685,48 @@ public class DalamudUtilService : IHostedService, IMediatorSubscriber
         }
 
         return result;
+    }
+
+    private void TargetPairByTargetType(Pair? pair, TargetType targetType)
+    {
+        if (_clientState.IsPvP) return;
+
+        IGameObject? objectToTarget;
+        if (pair is null)
+            objectToTarget = null;
+        else
+        {
+
+            var name = pair.PlayerName;
+            if (string.IsNullOrEmpty(name))
+                return;
+
+            var addr = _playerCharas.FirstOrDefault(f => string.Equals(f.Value.Name, name, StringComparison.Ordinal)).Value.Address;
+            if (addr == nint.Zero)
+                return;
+
+            objectToTarget = CreateGameObject(addr);
+        }
+        _ = RunOnFrameworkThread(() =>
+        {
+            switch (targetType)
+            {
+                case TargetType.Target:
+                    _targetManager.Target = objectToTarget;
+                    break;
+                case TargetType.SoftTarget:
+                    _targetManager.SoftTarget = objectToTarget;
+                    break;
+                case TargetType.FocusTarget:
+                    _targetManager.FocusTarget = objectToTarget;
+                    break;
+                case TargetType.MouseOverTarget:
+                    _targetManager.MouseOverTarget = objectToTarget;
+                    break;
+                default:
+                    break;
+            }
+        }).ConfigureAwait(false);
     }
 
     private unsafe void CheckCharacterForDrawing(nint address, string characterName)

--- a/PlayerSync/Services/DalamudUtilService.cs
+++ b/PlayerSync/Services/DalamudUtilService.cs
@@ -692,23 +692,22 @@ public class DalamudUtilService : IHostedService, IMediatorSubscriber
         if (_clientState.IsPvP) return;
 
         IGameObject? objectToTarget;
-        if (pair is null)
-            objectToTarget = null;
-        else
+        nint addr = nint.Zero;
+        if (pair != null)
         {
-
             var name = pair.PlayerName;
             if (string.IsNullOrEmpty(name))
                 return;
 
-            var addr = _playerCharas.FirstOrDefault(f => string.Equals(f.Value.Name, name, StringComparison.Ordinal)).Value.Address;
+            addr = _playerCharas.FirstOrDefault(f => string.Equals(f.Value.Name, name, StringComparison.Ordinal)).Value.Address;
             if (addr == nint.Zero)
                 return;
-
-            objectToTarget = CreateGameObject(addr);
         }
+            
         _ = RunOnFrameworkThread(() =>
         {
+            objectToTarget = pair != null ? CreateGameObject(addr) : null;
+
             switch (targetType)
             {
                 case TargetType.Target:

--- a/PlayerSync/Services/Mediator/Messages.cs
+++ b/PlayerSync/Services/Mediator/Messages.cs
@@ -81,7 +81,8 @@ public record PlayerUploadingMessage(GameObjectHandler Handler, bool IsUploading
 public record ClearProfileDataMessage(UserData? UserData = null, bool UpdateProfileStatus = false) : MessageBase;
 public record UserPairStickyPauseAndRemoveMessage(UserData UserData) : MessageBase;
 public record CyclePauseMessage(UserData UserData) : MessageBase;
-public record PauseMessage(UserData UserData, PauseReason Reason) : MessageBase;
+public record PauseMessage(UserData UserData, PauseReason Reason, PauseDuration? PauseDuration) : MessageBase;
+public record UnPauseMessage(UserData UserData, bool Notification) : MessageBase;
 public record ProfilePopoutToggle(Pair? Pair) : MessageBase;
 public record CompactUiChange(Vector2 Size, Vector2 Position) : MessageBase;
 public record ProfileOpenStandaloneMessage(Pair Pair) : MessageBase;

--- a/PlayerSync/Services/Mediator/Messages.cs
+++ b/PlayerSync/Services/Mediator/Messages.cs
@@ -9,6 +9,7 @@ using MareSynchronos.MareConfiguration.Models;
 using MareSynchronos.PlayerData.Handlers;
 using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services.Events;
+using MareSynchronos.Services.Models;
 using MareSynchronos.WebAPI.Files.Models;
 using System.Collections.Concurrent;
 using System.Numerics;
@@ -97,7 +98,7 @@ public record OpenSyncshellProfilePanel(GroupFullInfoDto GroupInfo) : MessageBas
 public record OpenPermissionWindow(Pair Pair) : MessageBase;
 public record DownloadLimitChangedMessage() : SameThreadMessage;
 public record CensusUpdateMessage(byte Gender, byte RaceId, byte TribeId) : MessageBase;
-public record TargetPairMessage(Pair Pair) : MessageBase;
+public record TargetPairMessage(Pair? Pair, TargetType TargetType) : MessageBase;
 public record CombatOrPerformanceStartMessage : MessageBase;
 public record CombatOrPerformanceEndMessage : MessageBase;
 public record EventMessage(Event Event) : MessageBase;

--- a/PlayerSync/Services/Models/TargetType.cs
+++ b/PlayerSync/Services/Models/TargetType.cs
@@ -1,0 +1,18 @@
+﻿namespace MareSynchronos.Services.Models;
+
+// https://dalamud.dev/api/Dalamud.Plugin.Services/Interfaces/ITargetManager
+
+/// <summary>
+/// Target types as defined by the Dalamud ITargetManager.
+/// Note: These are not the same as the ClientStructs TargetType enum.
+/// </summary>
+public enum TargetType
+{
+    Target,
+    MouseOverTarget,
+    FocusTarget,
+    PreviousTarget,
+    SoftTarget,
+    GPoseTarget,
+    MouseOverNameplateTarget
+}

--- a/PlayerSync/Services/PlayerPerformanceService.cs
+++ b/PlayerSync/Services/PlayerPerformanceService.cs
@@ -141,16 +141,17 @@ public class PlayerPerformanceService
         if (CheckForThreshold(config.AutoPausePlayersExceedingThresholds, config.TrisAutoPauseThresholdThousands * 1000,
             triUsage, config.AutoPausePlayersWithPreferredPermissionsExceedingThresholds, isPrefPerm))
         {
+            var pauseDuration = _playerPerformanceConfigService.Current.PauseDurationAutoPauseExceedingThresholds;
             _mediator.Publish(new NotificationMessage($"{pair.PlayerName} ({pair.UserData.AliasOrUID}) automatically paused",
                 $"Player {pair.PlayerName} ({pair.UserData.AliasOrUID}) exceeded your configured triangle auto pause threshold (" +
                 $"{triUsage}/{config.TrisAutoPauseThresholdThousands * 1000} triangles)" +
-                $" and has been automatically paused.",
+                $" and has been automatically paused " + GetPauseDurationText(pauseDuration),
                 MareConfiguration.Models.NotificationType.Warning));
 
             _mediator.Publish(new EventMessage(new Event(pair.PlayerName, pair.UserData, nameof(PlayerPerformanceService), EventSeverity.Warning,
                 $"Exceeds triangle threshold: automatically paused ({triUsage}/{config.TrisAutoPauseThresholdThousands * 1000} triangles)")));
 
-            _mediator.Publish(new PauseMessage(pair.UserData, PauseReason.ThresholdTriangles));
+            _mediator.Publish(new PauseMessage(pair.UserData, PauseReason.ThresholdTriangles, pauseDuration));
 
             return false;
         }
@@ -220,13 +221,14 @@ public class PlayerPerformanceService
         if (CheckForThreshold(config.AutoPausePlayersExceedingThresholds, config.VRAMSizeAutoPauseThresholdMiB * 1024 * 1024,
             vramUsage, config.AutoPausePlayersWithPreferredPermissionsExceedingThresholds, isPrefPerm))
         {
+            var pauseDuration = _playerPerformanceConfigService.Current.PauseDurationAutoPauseExceedingThresholds;
             _mediator.Publish(new NotificationMessage($"{pair.PlayerName} ({pair.UserData.AliasOrUID}) automatically paused",
                 $"Player {pair.PlayerName} ({pair.UserData.AliasOrUID}) exceeded your configured VRAM auto pause threshold (" +
                 $"{UiSharedService.ByteToString(vramUsage, addSuffix: true)}/{config.VRAMSizeAutoPauseThresholdMiB}MiB)" +
-                $" and has been automatically paused.",
+                $" and has been automatically paused " + GetPauseDurationText(pauseDuration),
                 MareConfiguration.Models.NotificationType.Warning));
 
-            _mediator.Publish(new PauseMessage(pair.UserData, PauseReason.ThresholdVram));
+            _mediator.Publish(new PauseMessage(pair.UserData, PauseReason.ThresholdVram, pauseDuration));
 
             _mediator.Publish(new EventMessage(new Event(pair.PlayerName, pair.UserData, nameof(PlayerPerformanceService), EventSeverity.Warning,
                 $"Exceeds VRAM threshold: automatically paused ({UiSharedService.ByteToString(vramUsage, addSuffix: true)}/{config.VRAMSizeAutoPauseThresholdMiB} MiB)")));
@@ -293,19 +295,32 @@ public class PlayerPerformanceService
 
         if (pauseRspExceeded)
         {
+            var pauseDuration = _playerPerformanceConfigService.Current.PauseDurationAutoPauseExceedingHeightThresholds;
             _logger.LogInformation("Pair {name} exceeds your height min/max threshold and will be paused.", pair.PlayerName);
             if (shouldWarn)
             {
                 var threshold = manualHeight ? maxHeight : maxThreshold;
                 _mediator.Publish(new NotificationMessage($"{pair.PlayerName} ({pair.UserData.AliasOrUID}) automatically paused",
-                $"Player {pair.PlayerName} ({pair.UserData.AliasOrUID}) exceeded your configured player height threshold and has been automatically paused. " +
+                $"Player {pair.PlayerName} ({pair.UserData.AliasOrUID}) exceeded your configured player height threshold and has been automatically paused " + GetPauseDurationText(pauseDuration) +
                 $"Their height: {actualHeight:F2}, your threshold: {threshold:F2}",
                 MareConfiguration.Models.NotificationType.Warning));
             }
-            _mediator.Publish(new PauseMessage(pair.UserData, PauseReason.ThresholdHeight));
+            _mediator.Publish(new PauseMessage(pair.UserData, PauseReason.ThresholdHeight, pauseDuration));
 
             return false;
         }
         return true;
+    }
+
+    private static string GetPauseDurationText(PauseDuration pauseDuration)
+    {
+        return pauseDuration switch
+        {
+            PauseDuration.ThirtyMinutes => "for 30 minutes. ",
+            PauseDuration.FourHours => "for 4 hours. ",
+            PauseDuration.EightHours => "for 8 hours. ",
+            PauseDuration.Indefinitely => "until you unpause them. ",
+            _ => string.Empty
+        };
     }
 }

--- a/PlayerSync/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/PlayerSync/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -490,6 +490,18 @@ public class ServerConfigurationManager
         return PauseReason.None;
     }
 
+    internal Dictionary<string, DateTimeOffset> GetPendingPausedPairUIDs()
+    {
+        try
+        {
+            return CurrentNotesStorage().PendingPausedPairs;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
     internal string? GetPendingRequestNameForIdent(string ident)
     {
         if (CurrentNotesStorage().PendingRequests.TryGetValue(ident, out var name))
@@ -583,6 +595,12 @@ public class ServerConfigurationManager
         _notesConfig.Save();
     }
 
+    internal void RemovePendingPauseForUid(string uid)
+    {
+        CurrentNotesStorage().PendingPausedPairs.Remove(uid);
+        _notesConfig.Save();
+    }
+
     internal void RemovePendingRequestForIdent(string ident)
     {
         CurrentNotesStorage().PendingRequests.Remove(ident);
@@ -648,6 +666,18 @@ public class ServerConfigurationManager
         }
         if (save)
             _notesConfig.Save();
+    }
+
+    internal void SetPauseTimeoutForUid(string uid, PauseDuration pairPauseDuration)
+    {
+        if (string.IsNullOrEmpty(uid)) return;
+        int minutes = (int)pairPauseDuration;
+        if (minutes <= 0) return;
+
+        var pauseDuration = TimeSpan.FromMinutes(minutes);
+
+        CurrentNotesStorage().PendingPausedPairs[uid] = DateTimeOffset.UtcNow.Add(pauseDuration);
+        _notesConfig.Save();
     }
 
     internal void AddPendingRequestForIdent(string ident, string name)

--- a/PlayerSync/UI/Components/DrawUserPair.cs
+++ b/PlayerSync/UI/Components/DrawUserPair.cs
@@ -12,6 +12,7 @@ using MareSynchronos.MareConfiguration;
 using MareSynchronos.MareConfiguration.Models;
 using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services;
+using MareSynchronos.Services.Models;
 using MareSynchronos.Services.Mediator;
 using MareSynchronos.Services.ServerConfiguration;
 using MareSynchronos.UI.Handlers;
@@ -34,6 +35,7 @@ public class DrawUserPair
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly UiSharedService _uiSharedService;
     private readonly PlayerPerformanceConfigService _performanceConfigService;
+    private readonly MareConfigService _configService;
     private readonly CharaDataManager _charaDataManager;
     private readonly IpcManager _ipcManager;
     private float _menuWidth = -1;
@@ -47,7 +49,7 @@ public class DrawUserPair
         MareMediator mareMediator, SelectTagForPairUi selectTagForPairUi,
         ServerConfigurationManager serverConfigurationManager,
         UiSharedService uiSharedService, PlayerPerformanceConfigService performanceConfigService,
-        CharaDataManager charaDataManager, IpcManager ipcManager)
+        MareConfigService mareConfigService, CharaDataManager charaDataManager, IpcManager ipcManager)
     {
         _id = id;
         _pair = entry;
@@ -60,6 +62,7 @@ public class DrawUserPair
         _serverConfigurationManager = serverConfigurationManager;
         _uiSharedService = uiSharedService;
         _performanceConfigService = performanceConfigService;
+        _configService = mareConfigService;
         _charaDataManager = charaDataManager;
         _ipcManager = ipcManager;
     }
@@ -362,7 +365,8 @@ public class DrawUserPair
             userPairText = _pair.UserData.AliasOrUID + " is visible: " + _pair.PlayerName + Environment.NewLine + "Click to target this player";
             if (ImGui.IsItemClicked())
             {
-                _mediator.Publish(new TargetPairMessage(_pair));
+                var useFocusTarget = _configService.Current.UseFocusTarget;
+                _mediator.Publish(new TargetPairMessage(_pair, useFocusTarget ? TargetType.FocusTarget : TargetType.Target));
             }
         }
         else

--- a/PlayerSync/UI/Components/DrawUserPair.cs
+++ b/PlayerSync/UI/Components/DrawUserPair.cs
@@ -36,6 +36,7 @@ public class DrawUserPair
     private readonly CharaDataManager _charaDataManager;
     private readonly IpcManager _ipcManager;
     private float _menuWidth = -1;
+    private float _pauseMenuWidth = -1;
     private bool _wasHovered = false;
     private List<AddressBookEntry>? _addressBookCache;
 
@@ -202,34 +203,16 @@ public class DrawUserPair
         }
         if (!_pair.UserPair!.OwnPermissions.IsPaused())
         {
+            var buttonHovered = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonHovered));
+            var buttonActive = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonActive));
+
+            ImGui.PushStyleColor(ImGuiCol.HeaderHovered, buttonHovered);
+            ImGui.PushStyleColor(ImGuiCol.HeaderActive, buttonActive);
             try
             {
-                var buttonHovered = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonHovered));
-                var buttonActive = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonActive));
-
-                ImGui.PushStyleColor(ImGuiCol.HeaderHovered, buttonHovered);
-                ImGui.PushStyleColor(ImGuiCol.HeaderActive, buttonActive);
-
                 if (ImGui.BeginMenu("Pause Pair"))
                 {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Pause for 30 minutes", _menuWidth, true))
-                    {
-                        _ = _apiController.PauseAsync(_pair.UserData, PauseReason.Manual, PauseDuration.ThirtyMinutes);
-                    }
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Pause for 4 hours", _menuWidth, true))
-                    {
-                        _ = _apiController.PauseAsync(_pair.UserData, PauseReason.Manual, PauseDuration.FourHours);
-                    }
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Pause for 8 hours", _menuWidth, true))
-                    {
-                        _ = _apiController.PauseAsync(_pair.UserData, PauseReason.Manual, PauseDuration.EightHours);
-                    }
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Keep Paused Forever", _menuWidth, true) && UiSharedService.CtrlPressed())
-                    {
-                        _ = _apiController.UserPairStickyPauseAndRemove(_pair.UserData);
-                    }
-                    UiSharedService.AttachToolTip("Hold CTRL and click to keep " + entryUID + " paused forever");
-
+                    DrawPairPauseContent(_menuWidth);
                     ImGui.EndMenu();
                 }
             }
@@ -510,25 +493,21 @@ public class DrawUserPair
         ImGui.SameLine(currentRightSide);
         if (_uiSharedService.IconButton(pauseIcon))
         {
-            var perm = _pair.UserPair!.OwnPermissions;
-
-            if (UiSharedService.CtrlPressed() && !perm.IsPaused())
-            {
-                perm.SetSticky(true);
-            }
-            
-            if (!_pair.IsPaused)
-                _serverConfigurationManager.SetPauseReasonForUid(_pair.UserData.UID, PauseReason.Manual);
-
-            perm.SetPaused(!perm.IsPaused());
-            _ = _apiController.UserSetPairPermissions(new(_pair.UserData, perm));
+            ImGui.OpenPopup("PausePopup");
         }
-        UiSharedService.AttachToolTip(!_pair.UserPair!.OwnPermissions.IsPaused()
-            ? ("Pause pairing with " + _pair.UserData.AliasOrUID
-                + (_pair.UserPair!.OwnPermissions.IsSticky()
-                    ? string.Empty
-                    : UiSharedService.TooltipSeparator + "Hold CTRL to enable preferred permissions while pausing." + Environment.NewLine + "This will leave this pair paused even if unpausing syncshells including this pair."))
-            : "Resume pairing with " + _pair.UserData.AliasOrUID);
+        if (ImGui.BeginPopup("PausePopup"))
+        {
+            using (ImRaii.PushId($"pausePopup-{_pair.UserData.UID}"))
+            {
+                DrawPairPauseContent(_pauseMenuWidth);
+                if (_pauseMenuWidth <= 0)
+                {
+                    _pauseMenuWidth = ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
+                }
+            }
+
+            ImGui.EndPopup();
+        }
 
         if (_pair.IsPaired)
         {
@@ -775,5 +754,37 @@ public class DrawUserPair
             UiSharedService.AttachToolTip("Hold CTRL and SHIFT and click to transfer ownership of this Syncshell to "
                 + (_pair.UserData.AliasOrUID) + Environment.NewLine + "WARNING: This action is irreversible.");
         }
+    }
+
+    private void DrawPairPauseContent(float width)
+    {
+        ImGui.TextUnformatted($"Pair {_pair.UserData.AliasOrUID}");
+        ImGui.Separator();
+        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Pause, "Pause", width, true))
+        {
+            _mediator.Publish(new PauseMessage(_pair.UserData, PauseReason.Manual, PauseDuration.Indefinitely));
+        }
+        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Pause, "Pause for 30 minutes", width, true))
+        {
+            _mediator.Publish(new PauseMessage(_pair.UserData, PauseReason.Manual, PauseDuration.ThirtyMinutes));
+        }
+        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Pause, "Pause for 4 hours", width, true))
+        {
+            _mediator.Publish(new PauseMessage(_pair.UserData, PauseReason.Manual, PauseDuration.FourHours));
+        }
+        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Pause, "Pause for 8 hours", width, true))
+        {
+            _mediator.Publish(new PauseMessage(_pair.UserData, PauseReason.Manual, PauseDuration.EightHours));
+        }
+        ImGui.Separator();
+        using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
+        {
+            if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Block Pairing", width, true))
+            {
+                _mediator.Publish(new UserPairStickyPauseAndRemoveMessage(_pair.UserData));
+            }
+        }
+        UiSharedService.AttachToolTip("Hold CTRL and click to block pairing with " + _pair.UserData.AliasOrUID 
+            + Environment.NewLine + "This will leave this pair paused even if unpausing syncshells including this pair.");
     }
 }

--- a/PlayerSync/UI/Components/DrawUserPair.cs
+++ b/PlayerSync/UI/Components/DrawUserPair.cs
@@ -16,6 +16,7 @@ using MareSynchronos.Services.Mediator;
 using MareSynchronos.Services.ServerConfiguration;
 using MareSynchronos.UI.Handlers;
 using MareSynchronos.WebAPI;
+using System.Numerics;
 
 
 namespace MareSynchronos.UI.Components;
@@ -643,11 +644,32 @@ public class DrawUserPair
 
         if (Pair.LastLoadedSoundSinceRedraw != null)
         {
-            var icon = FontAwesomeIcon.VolumeOff;
+            var timepassed = DateTimeOffset.UtcNow - Pair.LastLoadedSoundSinceRedraw.Value;
+
+            FontAwesomeIcon icon = FontAwesomeIcon.VolumeOff;
+            Vector4 color;
+
+            if (timepassed.TotalSeconds <= 15)
+            {
+                color = ImGuiColors.HealerGreen;
+            }
+            else if (timepassed.TotalSeconds < 300)
+            {
+                color = ImGuiColors.DalamudYellow;
+            }
+            else
+            {
+                color = ImGuiColors.DalamudRed;
+            }
             currentRightSide -= _uiSharedService.GetIconSize(icon).X + spacingX;
             ImGui.SameLine(currentRightSide);
-            _uiSharedService.IconText(icon, ImGuiColors.HealerGreen);
-            UiSharedService.AttachToolTip($"Started playing modded audio {UiSharedService.ApproxElapsedTimeToString(DateTimeOffset.UtcNow - Pair.LastLoadedSoundSinceRedraw.Value)}.{UiSharedService.TooltipSeparator}CTRL + Click to disable sound sync with {_pair.UserData.AliasOrUID}.");
+            _uiSharedService.IconText(icon, color);
+
+            UiSharedService.AttachToolTip(
+                $"Started playing modded audio {UiSharedService.ApproxElapsedTimeToString(timepassed)}." +
+                $"{UiSharedService.TooltipSeparator}CTRL + Click to disable sound sync with {Pair.UserData.AliasOrUID}."
+            );
+
             if (ImGui.IsItemClicked(ImGuiMouseButton.Left) && UiSharedService.CtrlPressed())
             {
                 var perm = _pair.UserPair!.OwnPermissions;

--- a/PlayerSync/UI/Components/DrawUserPair.cs
+++ b/PlayerSync/UI/Components/DrawUserPair.cs
@@ -647,20 +647,9 @@ public class DrawUserPair
             var timepassed = DateTimeOffset.UtcNow - Pair.LastLoadedSoundSinceRedraw.Value;
 
             FontAwesomeIcon icon = FontAwesomeIcon.VolumeOff;
-            Vector4 color;
 
-            if (timepassed.TotalSeconds <= 15)
-            {
-                color = ImGuiColors.HealerGreen;
-            }
-            else if (timepassed.TotalSeconds < 300)
-            {
-                color = ImGuiColors.DalamudYellow;
-            }
-            else
-            {
-                color = ImGuiColors.DalamudRed;
-            }
+            var color = UiSharedService.TimePassedIconColor(timepassed);
+
             currentRightSide -= _uiSharedService.GetIconSize(icon).X + spacingX;
             ImGui.SameLine(currentRightSide);
             _uiSharedService.IconText(icon, color);

--- a/PlayerSync/UI/Components/DrawUserPair.cs
+++ b/PlayerSync/UI/Components/DrawUserPair.cs
@@ -17,13 +17,14 @@ using MareSynchronos.Services.Mediator;
 using MareSynchronos.Services.ServerConfiguration;
 using MareSynchronos.UI.Handlers;
 using MareSynchronos.WebAPI;
-using System.Numerics;
 
 
 namespace MareSynchronos.UI.Components;
 
 public class DrawUserPair
 {
+    private static Pair? _lastSoftTarget;
+
     protected readonly ApiController _apiController;
     protected readonly IdDisplayHandler _displayHandler;
     protected readonly MareMediator _mediator;
@@ -42,6 +43,7 @@ public class DrawUserPair
     private float _pauseMenuWidth = -1;
     private bool _wasHovered = false;
     private List<AddressBookEntry>? _addressBookCache;
+    private bool _shouldBeSoftTarget = false;
 
     public DrawUserPair(string id, Pair entry, List<GroupFullInfoDto> syncedGroups,
         GroupFullInfoDto? currentGroup,
@@ -83,8 +85,29 @@ public class DrawUserPair
             DrawName(posX, rightSide);
             _displayHandler.DrawProfileIcon(_pair);
         }
-        _wasHovered = ImGui.IsItemHovered();
         color.Dispose();
+
+        _wasHovered = ImGui.IsItemHovered();
+
+        if (_configService.Current.SoftTargetPairsOnHover)
+        {
+            bool thisPairIsSelected = _lastSoftTarget?.UserData.UID == _pair.UserData.UID;
+            Pair? softTarget = null;
+            if (_wasHovered && !thisPairIsSelected)
+                softTarget = _pair;
+
+            if ((_lastSoftTarget == null && softTarget != null) || (softTarget != null && (_lastSoftTarget?.PlayerName != softTarget.PlayerName)))
+            {
+                _lastSoftTarget = softTarget;
+                _mediator.Publish(new TargetPairMessage(softTarget, TargetType.SoftTarget));
+            }
+
+            if (!TableHelper.IsMouseWithinWindow() && _lastSoftTarget != null && _lastSoftTarget == _pair && !string.IsNullOrEmpty(_uiSharedService.PlayerSoftTargetname))
+            {
+                _lastSoftTarget = null;
+                _mediator.Publish(new TargetPairMessage(null, TargetType.SoftTarget));
+            }
+        }
     }
 
     private void DrawCommonClientMenu()

--- a/PlayerSync/UI/Components/DrawUserPair.cs
+++ b/PlayerSync/UI/Components/DrawUserPair.cs
@@ -202,11 +202,41 @@ public class DrawUserPair
         }
         if (!_pair.UserPair!.OwnPermissions.IsPaused())
         {
-            if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Keep Paused", _menuWidth, true) && UiSharedService.CtrlPressed())
+            try
             {
-                _ = _apiController.UserPairStickyPauseAndRemove(_pair.UserData);
+                var buttonHovered = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonHovered));
+                var buttonActive = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonActive));
+
+                ImGui.PushStyleColor(ImGuiCol.HeaderHovered, buttonHovered);
+                ImGui.PushStyleColor(ImGuiCol.HeaderActive, buttonActive);
+
+                if (ImGui.BeginMenu("Pause Pair"))
+                {
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Pause for 30 minutes", _menuWidth, true))
+                    {
+                        _ = _apiController.PauseAsync(_pair.UserData, PauseReason.Manual, PauseDuration.ThirtyMinutes);
+                    }
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Pause for 4 hours", _menuWidth, true))
+                    {
+                        _ = _apiController.PauseAsync(_pair.UserData, PauseReason.Manual, PauseDuration.FourHours);
+                    }
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Pause for 8 hours", _menuWidth, true))
+                    {
+                        _ = _apiController.PauseAsync(_pair.UserData, PauseReason.Manual, PauseDuration.EightHours);
+                    }
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Times, "Keep Paused Forever", _menuWidth, true) && UiSharedService.CtrlPressed())
+                    {
+                        _ = _apiController.UserPairStickyPauseAndRemove(_pair.UserData);
+                    }
+                    UiSharedService.AttachToolTip("Hold CTRL and click to keep " + entryUID + " paused forever");
+
+                    ImGui.EndMenu();
+                }
             }
-            UiSharedService.AttachToolTip("Hold CTRL and click to keep paused " + entryUID);
+            finally
+            {
+                ImGui.PopStyleColor(2);
+            }
         }
         else
         {

--- a/PlayerSync/UI/DrawEntityFactory.cs
+++ b/PlayerSync/UI/DrawEntityFactory.cs
@@ -22,6 +22,7 @@ public class DrawEntityFactory
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly UiSharedService _uiSharedService;
     private readonly PlayerPerformanceConfigService _playerPerformanceConfigService;
+    private readonly MareConfigService _configService;
     private readonly CharaDataManager _charaDataManager;
     private readonly SelectTagForPairUi _selectTagForPairUi;
     private readonly TagHandler _tagHandler;
@@ -34,7 +35,8 @@ public class DrawEntityFactory
         SelectTagForPairUi selectTagForPairUi, MareMediator mediator,
         TagHandler tagHandler, SelectPairForTagUi selectPairForTagUi,
         ServerConfigurationManager serverConfigurationManager, UiSharedService uiSharedService,
-        PlayerPerformanceConfigService playerPerformanceConfigService, CharaDataManager charaDataManager, PairManager pairManager,
+        PlayerPerformanceConfigService playerPerformanceConfigService, MareConfigService mareConfigService,
+        CharaDataManager charaDataManager, PairManager pairManager,
         IBroadcastManager broadcastManager, IpcManager ipcManager)
     {
         _logger = logger;
@@ -47,6 +49,7 @@ public class DrawEntityFactory
         _serverConfigurationManager = serverConfigurationManager;
         _uiSharedService = uiSharedService;
         _playerPerformanceConfigService = playerPerformanceConfigService;
+        _configService = mareConfigService;
         _charaDataManager = charaDataManager;
         _broadcastManager = broadcastManager;
         _pairManager = pairManager;
@@ -73,8 +76,8 @@ public class DrawEntityFactory
     public DrawUserPair CreateDrawPair(string id, Pair user, List<GroupFullInfoDto> groups, GroupFullInfoDto? currentGroup)
     {
         return new DrawUserPair(id + user.UserData.UID, user, groups, currentGroup, _apiController, _uidDisplayHandler,
-            _mediator, _selectTagForPairUi, _serverConfigurationManager, _uiSharedService, _playerPerformanceConfigService,
-            _charaDataManager, _ipcManager);
+            _mediator, _selectTagForPairUi, _serverConfigurationManager, _uiSharedService, _playerPerformanceConfigService, 
+            _configService, _charaDataManager, _ipcManager);
     }
 
     public DrawBroadcastGroup CreateDrawBroadcastGroup(GroupBroadcastDto broadcast, IReadOnlyList<GroupFullInfoDto> groups)

--- a/PlayerSync/UI/Handlers/IdDisplayHandler.cs
+++ b/PlayerSync/UI/Handlers/IdDisplayHandler.cs
@@ -98,7 +98,15 @@ public class IdDisplayHandler
         {
             ImGui.AlignTextToFramePadding();
 
-            using (ImRaii.PushFont(UiBuilder.MonoFont, textIsUid)) ImGui.TextUnformatted(playerText);
+            var highlighter = _uiSharedService.ShouldHighlightOnHover(pair);
+
+            using (ImRaii.PushFont(UiBuilder.MonoFont, textIsUid))
+            {
+                using (ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(highlighter.Item2), highlighter.Item1))
+                {
+                    ImGui.TextUnformatted(playerText);
+                }
+            }
 
             if (ImGui.IsItemHovered())
             {

--- a/PlayerSync/UI/PlayerAnalysisViewerUI.cs
+++ b/PlayerSync/UI/PlayerAnalysisViewerUI.cs
@@ -522,20 +522,8 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                         var timepassed = DateTimeOffset.UtcNow - pair.LastLoadedSoundSinceRedraw.Value;
 
                         FontAwesomeIcon icon = FontAwesomeIcon.VolumeOff;
-                        Vector4 color;
 
-                        if (timepassed.TotalSeconds <= 15)
-                        {
-                            color = ImGuiColors.HealerGreen;
-                        }
-                        else if (timepassed.TotalSeconds < 300)
-                        {
-                            color = ImGuiColors.DalamudYellow;
-                        }
-                        else
-                        {
-                            color = ImGuiColors.DalamudRed;
-                        }                       
+                        var color = UiSharedService.TimePassedIconColor(timepassed);                 
 
                         _uiSharedService.IconText(icon, color);
 

--- a/PlayerSync/UI/PlayerAnalysisViewerUI.cs
+++ b/PlayerSync/UI/PlayerAnalysisViewerUI.cs
@@ -38,6 +38,8 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
     private readonly Dictionary<string, UserPermissions> _edited = new(StringComparer.Ordinal);
     public float idmaxl = ImGui.CalcTextSize("WWWWWWWWWWWW").X; //calculate width of 11 W's, UID are only 10 and w are usually max width as far as the glyphs advance is concerned, so using it as a width anchor, is fine. so this provides ample padding but still consistent. The number of W's can be adjusted to your liking but 11 suffices visually.
     private readonly UiTheme _theme;
+    private Pair? _lastSoftTarget = null;
+    private bool _softTargetOnRowSelect = false;
 
     public PlayerAnalysisViewerUI(ILogger<PlayerAnalysisViewerUI> logger, MareMediator mediator, PerformanceCollectorService performanceCollector,
         UiSharedService uiSharedService, PairManager pairManager, PlayerPerformanceConfigService playerPerformanceConfigService, ServerConfigurationManager serverConfigurationManager,
@@ -121,7 +123,10 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
 
         DrawFPS();
 
-        Ui.DrawHorizontalRule(_theme);
+        //Ui.DrawHorizontalRule(_theme);
+        ImGuiHelpers.ScaledDummy(2f);
+        ImGui.Separator();
+        ImGuiHelpers.ScaledDummy(2f);
 
         _selectedTabAnalysis.TabAction.Invoke();
     }
@@ -159,20 +164,22 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
         }
 
         var headerStart = ImGui.GetCursorPos();
+        ImGui.SetCursorPosY(headerStart.Y - 8f * ImGuiHelpers.GlobalScale);
         _uiSharedService.BigText($"Visible Players ({_cachedVisiblePairs.Count})");
-        var headerSize = ImGui.GetItemRectSize();
+        ImGui.SameLine();
+        ImGui.SetCursorPosY(headerStart.Y);
+        ImGui.Checkbox("Enable SoftTarget on row selection.", ref _softTargetOnRowSelect);
 
         var style = ImGui.GetStyle();
         float comboW = 150f * ImGuiHelpers.GlobalScale;
         float updateW = ImGui.CalcTextSize("Update").X + style.FramePadding.X * 2f;
         float controlsW = comboW + style.ItemSpacing.X + updateW;
-
         float contentMinX = ImGui.GetWindowContentRegionMin().X;
         float contentMaxX = ImGui.GetWindowContentRegionMax().X;
         float controlsX = MathF.Max(contentMinX, contentMaxX - controlsW);
-        float controlsY = headerStart.Y + (headerSize.Y - ImGui.GetFrameHeight()) * 0.5f;
 
-        ImGui.SetCursorPos(new Vector2(controlsX, controlsY));
+        ImGui.SameLine(controlsX);
+        ImGui.SetCursorPosY(headerStart.Y);
         ImGui.SetNextItemWidth(comboW);
         _uiSharedService.DrawCombo("###refreshInterval", [RefreshMode.Live, RefreshMode.Sec5, RefreshMode.Sec30, RefreshMode.Manual],
             (s) => s switch
@@ -197,15 +204,13 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                 }
             }, RefreshMode.Live);
         ImGui.SameLine();
+        ImGui.SetCursorPosY(headerStart.Y);
         if (ImGui.Button("Update"))
         {
             _manualRefresh = true;
         }
 
-        float rowBottomY = MathF.Max(headerStart.Y + headerSize.Y, controlsY + ImGui.GetFrameHeight());
-        ImGui.SetCursorPos(new Vector2(headerStart.X, rowBottomY));
-
-        ImGuiHelpers.ScaledDummy(8f);
+        ImGuiHelpers.ScaledDummy(2f);
         ImGui.Separator();
 
         if (shouldUpdate || _manualRefresh)
@@ -380,14 +385,14 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                         maxVRAMWidth = vrwidth;
                 }
 
+                Pair? softTarget = null;
+
                 // time to draw table data.
                 foreach (var pair in sortedPairs)
                 {
                     ImGui.PushID(pair.UserData.UID);
 
-                    bool shouldHighlight = !string.IsNullOrWhiteSpace(_dalamudUtilService.TargetName)
-                        && !string.IsNullOrWhiteSpace(pair.PlayerName)
-                        && _dalamudUtilService.TargetName == pair.PlayerName;
+                    var highlighter = _uiSharedService.ShouldHighlightOnHover(pair);
 
                     float rowStartHeightStart = ImGui.GetCursorPosY();
 
@@ -408,7 +413,7 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     // UID Column                     
                     ImGui.TableSetColumnIndex(1);
                     ImGui.AlignTextToFramePadding();
-                    using var targetColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(ImGuiColors.ParsedGreen), shouldHighlight);
+                    using var targetColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(highlighter.Item2), highlighter.Item1);
                     TableHelper.CText(pair.UserData.UID, centerHorizontally: false, leftPadding: 0f);
                     targetColor.Dispose();
                     if (ImGui.IsItemHovered()) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -443,7 +448,7 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     // Alias/vanity Column
                     ImGui.TableSetColumnIndex(2);
                     ImGui.AlignTextToFramePadding();
-                    using var aliasColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(ImGuiColors.ParsedGreen), shouldHighlight);
+                    using var aliasColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(highlighter.Item2), highlighter.Item1);
                     TableHelper.CText(pair.UserData.Alias ?? "", centerHorizontally: false, leftPadding: 0f);
                     aliasColor.Dispose();                    
 
@@ -606,16 +611,28 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     {
                         _ = _apiController.CyclePauseAsync(pair.UserData);
                     }
- 
+
+                    
                     if (TableHelper.SRowhovered(rowStartHeightStart, ImGui.GetCursorPosY()))
                     {
                         var rowIndex = ImGui.TableGetRowIndex();
                         //uint color = ImGui.ColorConvertFloat4ToU32(new Vector4(0.4f, 0.6f, 1.0f, 0.5f));
                         var color = ImGui.GetColorU32(ImGuiCol.HeaderHovered);
                         ImGui.TableSetBgColor(ImGuiTableBgTarget.RowBg1, color, rowIndex);
+                        softTarget = pair;
                     }
 
                     ImGui.PopID();
+                }
+
+                if (_softTargetOnRowSelect)
+                {
+                    if ((_lastSoftTarget == null && softTarget != null) || (_lastSoftTarget?.PlayerName != softTarget?.PlayerName))
+                    {
+                        _lastSoftTarget = softTarget;
+                        Mediator.Publish(new TargetPairMessage(softTarget, TargetType.SoftTarget));
+                        _logger.LogTrace("PAV SoftTarget: {name}", softTarget?.PlayerName ?? "None");
+                    }
                 }
             }
             finally
@@ -632,6 +649,8 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
         bool FilterPausedUsers(KeyValuePair<Pair, List<GroupFullInfoDto>> u) => u.Key.IsPaused;
         var allPausedPairs = ImmutablePairList(allPairs.Where(FilterPausedUsers));
 
+        var headerStart = ImGui.GetCursorPos();
+        ImGui.SetCursorPosY(headerStart.Y - 8f * ImGuiHelpers.GlobalScale);
         _uiSharedService.BigText("Paused Pairs");
         ImGuiHelpers.ScaledDummy(2f);
         ImGui.Separator();
@@ -701,12 +720,13 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
     private void DrawPermissions()
     {
         using var imGuiUid = ImRaii.PushId("permissions");
+        var headerStart = ImGui.GetCursorPos();
+        ImGui.SetCursorPosY(headerStart.Y - 8f * ImGuiHelpers.GlobalScale);
         _uiSharedService.BigText("Permissions Matrix");
         ImGuiHelpers.ScaledDummy(2f);
         ImGui.Separator();
 
-        UiSharedService.TextWrapped("Checking Preferred Permissions means Syncshells won't overwrite permissions, such as pause/unpause.");
-        ImGui.Separator();
+        UiSharedService.ColorTextWrapped("Checking Preferred Permissions means Syncshells won't overwrite permissions, such as pause/unpause.", ImGuiColors.DalamudRed);
         UiSharedService.ColorTextWrapped("Checking the permission boxes means disabling that permission.", ImGuiColors.DalamudYellow);
         UiSharedService.TextWrapped("Both sides must have the permission enabled for it to take effect on either side.");
         UiSharedService.TextWrapped("This means, make sure you uncheck the box and click save to enable permissions with the paired player.");
@@ -778,10 +798,8 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     bool ownSound = edit.IsDisableSounds();
                     bool ownAnimations = edit.IsDisableAnimations();
                     bool ownVfx = edit.IsDisableVFX();
-                    
-                    bool shouldHighlight = !string.IsNullOrWhiteSpace(_dalamudUtilService.TargetName) 
-                        && !string.IsNullOrWhiteSpace(pair.PlayerName)
-                        && _dalamudUtilService.TargetName == pair.PlayerName;
+
+                    var highlighter = _uiSharedService.ShouldHighlightOnHover(pair);
 
                     // Track change for state
                     bool changed = false;
@@ -792,8 +810,9 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     // UID
                     ImGui.TableNextColumn();
                     ImGui.AlignTextToFramePadding();
-                    using var targetColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(ImGuiColors.ParsedGreen), shouldHighlight);
+                    using var targetColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(highlighter.Item2), highlighter.Item1);
                     ImGui.TextUnformatted(uid);
+                    targetColor.Dispose();
                     if (ImGui.IsItemHovered()) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                     if (ImGui.IsItemClicked())
                     {
@@ -804,8 +823,9 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     // Alias
                     ImGui.TableNextColumn();
                     ImGui.AlignTextToFramePadding();
+                    using var aliasColor = ImRaii.PushColor(ImGuiCol.Text, UiSharedService.Color(highlighter.Item2), highlighter.Item1);
                     ImGui.TextUnformatted(pair.UserData.Alias ?? "");
-                    targetColor.Dispose();
+                    aliasColor.Dispose();
 
                     // Preferred
                     ImGui.TableNextColumn();

--- a/PlayerSync/UI/PlayerAnalysisViewerUI.cs
+++ b/PlayerSync/UI/PlayerAnalysisViewerUI.cs
@@ -519,9 +519,31 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
 
                     if (pair.LastLoadedSoundSinceRedraw != null)
                     {
-                        var icon = FontAwesomeIcon.VolumeOff;
-                        _uiSharedService.IconText(icon, ImGuiColors.HealerGreen);
-                        UiSharedService.AttachToolTip($"Started playing modded audio {UiSharedService.ApproxElapsedTimeToString(DateTimeOffset.UtcNow - pair.LastLoadedSoundSinceRedraw.Value)}.{UiSharedService.TooltipSeparator}CTRL + Click to disable sound sync with {pair.UserData.AliasOrUID}.");
+                        var timepassed = DateTimeOffset.UtcNow - pair.LastLoadedSoundSinceRedraw.Value;
+
+                        FontAwesomeIcon icon = FontAwesomeIcon.VolumeOff;
+                        Vector4 color;
+
+                        if (timepassed.TotalSeconds <= 15)
+                        {
+                            color = ImGuiColors.HealerGreen;
+                        }
+                        else if (timepassed.TotalSeconds < 300)
+                        {
+                            color = ImGuiColors.DalamudYellow;
+                        }
+                        else
+                        {
+                            color = ImGuiColors.DalamudRed;
+                        }                       
+
+                        _uiSharedService.IconText(icon, color);
+
+                        UiSharedService.AttachToolTip(
+                            $"Started playing modded audio {UiSharedService.ApproxElapsedTimeToString(timepassed)}." +
+                            $"{UiSharedService.TooltipSeparator}CTRL + Click to disable sound sync with {pair.UserData.AliasOrUID}."
+                        );
+
                         if (ImGui.IsItemClicked(ImGuiMouseButton.Left) && UiSharedService.CtrlPressed())
                         {
                             var perm = pair.UserPair!.OwnPermissions;

--- a/PlayerSync/UI/PlayerAnalysisViewerUI.cs
+++ b/PlayerSync/UI/PlayerAnalysisViewerUI.cs
@@ -10,6 +10,7 @@ using MareSynchronos.MareConfiguration;
 using MareSynchronos.MareConfiguration.Models;
 using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services;
+using MareSynchronos.Services.Models;
 using MareSynchronos.Services.Mediator;
 using MareSynchronos.Services.ServerConfiguration;
 using MareSynchronos.UI.ModernUi;
@@ -402,7 +403,7 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     _uiSharedService.IconText(FontAwesomeIcon.Eye, ImGuiColors.ParsedGreen);
                     UiSharedService.AttachToolTip("Target " + pair.PlayerName);
                     if (ImGui.IsItemHovered()) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
-                    if (ImGui.IsItemClicked()) Mediator.Publish(new TargetPairMessage(pair));
+                    if (ImGui.IsItemClicked()) Mediator.Publish(new TargetPairMessage(pair, TargetType.Target));
 
                     // UID Column                     
                     ImGui.TableSetColumnIndex(1);

--- a/PlayerSync/UI/PlayerAnalysisViewerUI.cs
+++ b/PlayerSync/UI/PlayerAnalysisViewerUI.cs
@@ -7,6 +7,7 @@ using MareSynchronos.API.Data.Enum;
 using MareSynchronos.API.Data.Extensions;
 using MareSynchronos.API.Dto.Group;
 using MareSynchronos.MareConfiguration;
+using MareSynchronos.MareConfiguration.Models;
 using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services;
 using MareSynchronos.Services.Mediator;
@@ -381,6 +382,8 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                 // time to draw table data.
                 foreach (var pair in sortedPairs)
                 {
+                    ImGui.PushID(pair.UserData.UID);
+
                     bool shouldHighlight = !string.IsNullOrWhiteSpace(_dalamudUtilService.TargetName)
                         && !string.IsNullOrWhiteSpace(pair.PlayerName)
                         && _dalamudUtilService.TargetName == pair.PlayerName;
@@ -533,25 +536,62 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                     }
 
                     // Button options Column
-                    var uid = pair.UserData.UID;
-                    bool isBusy = _pauseClicked.Contains(uid);
-
                     ImGui.TableSetColumnIndex(7);
                     ImGui.AlignTextToFramePadding();
-                    ImGui.BeginDisabled(isBusy);
-                    if (ImGui.Button($"Pause##{pair.UserData.UID}"))
+                    if (ImGui.Button("Pause"))
                     {
-                        // It can take a moment to dispose a large player, so we don't let the user spam the button
-                        if (_pauseClicked.Add(uid))
+                        ImGui.OpenPopup("PausePopup");
+                    }
+                    if (ImGui.BeginPopup("PausePopup"))
+                    {
+                        var buttonHovered = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonHovered));
+                        var buttonActive = ColorHelpers.RgbaUintToVector4(ImGui.GetColorU32(ImGuiCol.ButtonActive));
+
+                        ImGui.PushStyleColor(ImGuiCol.HeaderHovered, buttonHovered);
+                        ImGui.PushStyleColor(ImGuiCol.HeaderActive, buttonActive);
+                        try
                         {
-                            // This should be reworked and use the mediator to publish a pause message
-                            _ = _apiController.PauseAsync(pair.UserData, MareConfiguration.Models.PauseReason.Manual).ContinueWith(_ => _pauseClicked.Remove(uid));
+                            ImGui.TextUnformatted($"Pair {pair.UserData.AliasOrUID}");
+                            ImGui.Separator();
+                            if (ImGui.Selectable("Pause"))
+                            {
+                                Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.Indefinitely));
+                            }
+                            if (ImGui.Selectable("Pause for 30 minutes"))
+                            {
+                                Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.ThirtyMinutes));
+                            }
+
+                            if (ImGui.Selectable("Pause for 4 hours"))
+                            {
+                                Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.FourHours));
+                            }
+
+                            if (ImGui.Selectable("Pause for 8 hours"))
+                            {
+                                Mediator.Publish(new PauseMessage(pair.UserData, PauseReason.Manual, PauseDuration.EightHours));
+                            }
+                            ImGui.Separator();
+                            
+                            using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
+                            {
+                                if (ImGui.Selectable("Block Pairing") && UiSharedService.CtrlPressed())
+                                {
+                                    Mediator.Publish(new UserPairStickyPauseAndRemoveMessage(pair.UserData));
+                                }
+                            }
+                            UiSharedService.AttachToolTip("Hold CTRL and click to block pairing with " + pair.UserData.AliasOrUID
+                                + Environment.NewLine + "This will leave this pair paused even if unpausing syncshells including this pair.");
+                        }
+                        finally
+                        {
+                            ImGui.PopStyleColor(2);
+                            ImGui.EndPopup();
                         }
                     }
-                    ImGui.EndDisabled();
 
                     ImGui.SameLine();
-                    if (ImGui.Button($"Refresh##{pair.UserData.UID}"))
+                    if (ImGui.Button("Refresh"))
                     {
                         _ = _apiController.CyclePauseAsync(pair.UserData);
                     }
@@ -563,6 +603,8 @@ internal class PlayerAnalysisViewerUI : WindowMediatorSubscriberBase
                         var color = ImGui.GetColorU32(ImGuiCol.HeaderHovered);
                         ImGui.TableSetBgColor(ImGuiTableBgTarget.RowBg1, color, rowIndex);
                     }
+
+                    ImGui.PopID();
                 }
             }
             finally

--- a/PlayerSync/UI/SettingsUi.Interface.cs
+++ b/PlayerSync/UI/SettingsUi.Interface.cs
@@ -69,6 +69,7 @@ public partial class SettingsUi
         var showCompactStats = _configService.Current.ShowCompactStats;
         var mysterySetting = _configService.Current.MysterySetting;
         var showProfileIcon = _configService.Current.ShowProfileIconByNames;
+        var softTargetOnPairHover = _configService.Current.SoftTargetPairsOnHover;
 
         _uiShared.BigText("PlayerSync UI");
         ImGuiHelpers.ScaledDummy(2);
@@ -106,6 +107,12 @@ public partial class SettingsUi
                 _configService.Save();
             }
             if (!showAnalysisOnUi) ImGui.EndDisabled();
+        }
+
+        if (ImGui.Checkbox("SoftTarget players in game when moused over in the UI list.", ref softTargetOnPairHover))
+        {
+            _configService.Current.SoftTargetPairsOnHover = softTargetOnPairHover;
+            _configService.Save();
         }
 
         if (ImGui.Checkbox("Show separate Visible group", ref showVisibleSeparate))

--- a/PlayerSync/UI/SettingsUi.Interface.cs
+++ b/PlayerSync/UI/SettingsUi.Interface.cs
@@ -615,7 +615,7 @@ public partial class SettingsUi
         {
             ContextMenuItemId.None => "Do Not Show",
             ContextMenuItemId.OpenProfile => "Open Profile",
-            ContextMenuItemId.PauseForever => "Keep Paused",
+            ContextMenuItemId.PausePair => "Pause Pair (Submenu)",
             ContextMenuItemId.PairData => "Pair Data (Submenu)",
             ContextMenuItemId.InviteToSyncshell => "Invite To Syncshell (Submenu)",
             ContextMenuItemId.AddToOverrides => "Add to Overrides (Submenu)",

--- a/PlayerSync/UI/SettingsUi.Performance.cs
+++ b/PlayerSync/UI/SettingsUi.Performance.cs
@@ -7,6 +7,7 @@ using MareSynchronos.MareConfiguration.Configurations;
 using MareSynchronos.UI.ModernUi;
 using MareSynchronos.Services.Mediator;
 using System.Numerics;
+using MareSynchronos.MareConfiguration.Models;
 
 namespace MareSynchronos.UI;
 
@@ -227,7 +228,28 @@ public partial class SettingsUi
             ImGui.Text("(thousand triangles)");
             _uiShared.DrawHelpText("When a loading in player and their triangle count exceeds this amount, automatically pauses the synced player." + UiSharedService.TooltipSeparator
                 + "Default: 250 thousand");
+            ImGui.SetNextItemWidth(200 * ImGuiHelpers.GlobalScale);
+            _uiShared.DrawCombo("Auto Pause Duration##autoPauseThreshold", [
+                PauseDuration.ThirtyMinutes,
+                PauseDuration.FourHours,
+                PauseDuration.EightHours,
+                PauseDuration.Indefinitely
+            ],
+            (s) => s switch
+            {
+                PauseDuration.ThirtyMinutes => "Pause for 30 minutes",
+                PauseDuration.FourHours => "Pause for 4 hours",
+                PauseDuration.EightHours => "Pause for 8 hours",
+                PauseDuration.Indefinitely => "Indefinitely",
+                _ => throw new NotSupportedException()
+            }, (s) =>
+            {
+                _playerPerformanceConfigService.Current.PauseDurationAutoPauseExceedingThresholds = s;
+                _playerPerformanceConfigService.Save();
+            }, PauseDuration.Indefinitely);
         }
+        _uiShared.DrawHelpText("Pairs paused indefinitely require a manual unpause unless unpaused via a Syncshell resume.");
+
         ImGui.Dummy(new Vector2(10));
         _uiShared.BigText("Whitelisted UIDs");
         UiSharedService.TextWrapped("The entries in the list below will be ignored for all warnings and auto pause operations.");
@@ -301,6 +323,26 @@ public partial class SettingsUi
             }
         }
         UiSharedService.ColorTextWrapped("Toggle this feature off/on again after changing values to refresh pairs immediately.", ImGuiColors.DalamudRed);
+        ImGui.SetNextItemWidth(200 * ImGuiHelpers.GlobalScale);
+        _uiShared.DrawCombo("Auto Pause Duration##autoPauseHeight", [
+                PauseDuration.ThirtyMinutes,
+                PauseDuration.FourHours,
+                PauseDuration.EightHours,
+                PauseDuration.Indefinitely
+            ],
+            (s) => s switch
+            {
+                PauseDuration.ThirtyMinutes => "Pause for 30 minutes",
+                PauseDuration.FourHours => "Pause for 4 hours",
+                PauseDuration.EightHours => "Pause for 8 hours",
+                PauseDuration.Indefinitely => "Indefinitely",
+                _ => throw new NotSupportedException()
+            }, (s) =>
+            {
+                _playerPerformanceConfigService.Current.PauseDurationAutoPauseExceedingHeightThresholds = s;
+                _playerPerformanceConfigService.Save();
+            }, PauseDuration.Indefinitely);
+        _uiShared.DrawHelpText("Pairs paused indefinitely require a manual unpause unless unpaused via a Syncshell resume.");
 
         if (ImGui.Checkbox("Don't auto pause direct pairs exceeding thresholds", ref noAutoPausePairs))
         {
@@ -326,7 +368,7 @@ public partial class SettingsUi
             ImGui.AlignTextToFramePadding();
             ImGui.TextUnformatted("Pause players above ");
             ImGui.SameLine();
-            ImGui.SetNextItemWidth(200f);
+            ImGui.SetNextItemWidth(130f * ImGuiHelpers.GlobalScale);
             if (ImGui.SliderFloat("##max", ref maxHeightMultiplier, 100.0f, 500.0f, "%.0f%%"))
             {
                 _playerPerformanceConfigService.Current.MaxHeightMultiplier = maxHeightMultiplier;
@@ -356,7 +398,7 @@ public partial class SettingsUi
             ImGui.SameLine();
 
             // Feet
-            ImGui.SetNextItemWidth(60);
+            ImGui.SetNextItemWidth(40 * ImGuiHelpers.GlobalScale);
             changedImperial |= ImGui.InputInt("##maxFeet", ref _maxHeightFeet);
             ImGui.SameLine();
             ImGui.TextUnformatted("feet");
@@ -364,7 +406,7 @@ public partial class SettingsUi
             ImGui.SameLine();
 
             // Inches
-            ImGui.SetNextItemWidth(60);
+            ImGui.SetNextItemWidth(40 * ImGuiHelpers.GlobalScale);
             changedImperial |= ImGui.InputInt("##maxInches", ref _maxHeightInches);
             ImGui.SameLine();
             ImGui.TextUnformatted("inches or");
@@ -372,7 +414,7 @@ public partial class SettingsUi
             ImGui.SameLine();
 
             // Centimeters
-            ImGui.SetNextItemWidth(60);
+            ImGui.SetNextItemWidth(40 * ImGuiHelpers.GlobalScale);
             changedMetric |= ImGui.InputInt("##maxCm", ref _maxHeightCm);
             ImGui.SameLine();
             ImGui.TextUnformatted("cm");
@@ -401,7 +443,7 @@ public partial class SettingsUi
             }
         }
 
-        UiSharedService.ColorTextWrapped("Paused pairs must be manually unpaused.", ImGuiColors.DalamudYellow);
+        //UiSharedService.ColorTextWrapped("Paused pairs must be manually unpaused.", ImGuiColors.DalamudYellow);
         ImGui.Dummy(new Vector2(10));
 
         _uiShared.BigText("Whitelisted UIDs");

--- a/PlayerSync/UI/SettingsUi.Sync.cs
+++ b/PlayerSync/UI/SettingsUi.Sync.cs
@@ -211,6 +211,39 @@ public partial class SettingsUi
         _uiShared.DrawHelpText("Set the wait time in seconds between entering a zone and joining a ZoneSync." + UiSharedService.TooltipSeparator + "Increase this if you have pairing issues after zoning.");
 
         ImGuiHelpers.ScaledDummy(5f);
+
+        ImGui.TextWrapped("ZoneSync filters apply to ZoneSync-only pairs (not direct pairs or pairs from Syncshells.)");
+        UiSharedService.ColorTextWrapped("Changing these options will redraw all visible pairs around you.", ImGuiColors.DalamudRed);
+
+        bool filerAnimations = _zoneSyncConfigService.Current.ZoneSyncFilterAnimations;
+        bool filterSounds = _zoneSyncConfigService.Current.ZoneSyncFilterSounds;
+        bool filterVfx = _zoneSyncConfigService.Current.ZoneSyncFilterVfx;
+
+        if (ImGui.Checkbox("Filter Animations", ref filerAnimations))
+        {
+            _zoneSyncConfigService.Current.ZoneSyncFilterAnimations = filerAnimations;
+            _zoneSyncConfigService.Save();
+            Mediator.Publish(new ChangeFilterMessage());
+        }
+        _uiShared.DrawHelpText("Prevent the loading of modded animations for players only paired via ZoneSync.");
+
+        if (ImGui.Checkbox("Filter Sounds", ref filterSounds))
+        {
+            _zoneSyncConfigService.Current.ZoneSyncFilterSounds = filterSounds;
+            _zoneSyncConfigService.Save();
+            Mediator.Publish(new ChangeFilterMessage());
+        }
+        _uiShared.DrawHelpText("Prevent the loading of modded sounds for players only paired via ZoneSync.");
+
+        if (ImGui.Checkbox("Filter Vfx", ref filterVfx))
+        {
+            _zoneSyncConfigService.Current.ZoneSyncFilterVfx = filterVfx;
+            _zoneSyncConfigService.Save();
+            Mediator.Publish(new ChangeFilterMessage());
+        }
+        _uiShared.DrawHelpText("Prevent the loading of modded VFX for players only paired via ZoneSync.");
+
+        ImGuiHelpers.ScaledDummy(5f);
         UiSharedService.TextWrapped("ZoneSync Synchshell permissions are based on your Default Permission Settings.");
         UiSharedService.TextWrapped("Permissions can be found under Settings > Service Settings > Permission Settings.");
 

--- a/PlayerSync/UI/SettingsUi.cs
+++ b/PlayerSync/UI/SettingsUi.cs
@@ -111,7 +111,7 @@ public partial class SettingsUi : WindowMediatorSubscriberBase
 
         SizeConstraints = new WindowSizeConstraints
         {
-            MinimumSize = new Vector2(1000, 800),
+            MinimumSize = new Vector2(1000, 840),
             MaximumSize = new Vector2(1000, 2000),
         };
 

--- a/PlayerSync/UI/UISharedService.cs
+++ b/PlayerSync/UI/UISharedService.cs
@@ -129,7 +129,6 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
                 SizePx = 23
             }));
         });
-
         GameFont = _pluginInterface.UiBuilder.FontAtlas.NewGameFontHandle(new(GameFontFamilyAndSize.Axis12));
         IconFont = _pluginInterface.UiBuilder.IconFontFixedWidthHandle;
     }
@@ -149,7 +148,8 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
 
     public Dictionary<uint, string> JobData => _dalamudUtil.JobData.Value;
     public string PlayerName => _dalamudUtil.PlayerName;
-
+    public string PlayerTargetName => _dalamudUtil.TargetName;
+    public string PlayerSoftTargetname => _dalamudUtil.SoftTargetName;
     public IFontHandle UidFont { get; init; }
     public IFontHandle HeaderFont { get; init; }
     public Dictionary<ushort, string> WorldData => _dalamudUtil.WorldData.Value;
@@ -193,7 +193,6 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
             ImGui.EndTooltip();
         }
     }
-
 
     public static string ByteToString(long bytes, bool addSuffix = true)
     {
@@ -261,6 +260,27 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
     {
         using var raiicolor = ImRaii.PushColor(ImGuiCol.Text, color);
         TextWrapped(text, wrapPos);
+    }
+
+    public (bool, Vector4) ShouldHighlightOnHover(Pair pair)
+    {
+        bool shouldHighlightTarget = !string.IsNullOrWhiteSpace(_dalamudUtil.TargetName)
+                        && !string.IsNullOrWhiteSpace(pair.PlayerName)
+                        && _dalamudUtil.TargetName == pair.PlayerName;
+
+        bool shouldHighlightSoftTarget = !string.IsNullOrWhiteSpace(_dalamudUtil.SoftTargetName)
+            && !string.IsNullOrWhiteSpace(pair.PlayerName)
+            && _dalamudUtil.SoftTargetName == pair.PlayerName;
+
+
+        bool shouldHighlightMouseOverTarget = !string.IsNullOrWhiteSpace(_dalamudUtil.MouseOverTargetName)
+            && !string.IsNullOrWhiteSpace(pair.PlayerName)
+            && _dalamudUtil.MouseOverTargetName == pair.PlayerName;
+
+        bool shouldHighlight = shouldHighlightTarget || shouldHighlightSoftTarget || shouldHighlightMouseOverTarget;
+        var highlightColor = shouldHighlightTarget ? ImGuiColors.ParsedGreen : shouldHighlightSoftTarget ? ImGuiColors.TankBlue : ImGuiColors.DalamudYellow;
+
+        return (shouldHighlight, highlightColor);
     }
 
     public static bool CtrlPressed() => (GetKeyState(0xA2) & 0x8000) != 0 || (GetKeyState(0xA3) & 0x8000) != 0;

--- a/PlayerSync/UI/UISharedService.cs
+++ b/PlayerSync/UI/UISharedService.cs
@@ -1310,4 +1310,20 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
 
         return Vector4.Lerp(PlayerSyncLogoPalette[startColorIndex], PlayerSyncLogoPalette[endColorIndex], smoothedBlendAmount);
     }
+
+    public static Vector4 TimePassedIconColor(TimeSpan timepassed)
+    {
+        if (timepassed.TotalSeconds <= 15)
+        {
+            return ImGuiColors.HealerGreen;
+        }
+
+        if (timepassed.TotalSeconds < 300)
+        {
+            return ImGuiColors.DalamudYellow;
+        }
+
+        return ImGuiColors.DalamudRed;
+        
+    }
 }

--- a/PlayerSync/WebAPI/SignalR/ApiController.cs
+++ b/PlayerSync/WebAPI/SignalR/ApiController.cs
@@ -64,7 +64,8 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         //Mediator.Subscribe<UserAddPairMessage>(this, (msg) => _ = UserAddPair(new UserDto(msg.UserData), true));
         Mediator.Subscribe<CyclePauseMessage>(this, (msg) => _ = CyclePauseAsync(msg.UserData));
         Mediator.Subscribe<CensusUpdateMessage>(this, (msg) => _lastCensus = msg);
-        Mediator.Subscribe<PauseMessage>(this, (msg) => _ = PauseAsync(msg.UserData, msg.Reason));
+        Mediator.Subscribe<PauseMessage>(this, (msg) => _ = PauseAsync(msg.UserData, msg.Reason, msg.PauseDuration));
+        Mediator.Subscribe<UnPauseMessage>(this, (msg) => _ = UnPauseAsync(msg.UserData, msg.Notification));
         Mediator.Subscribe<UserPairStickyPauseAndRemoveMessage>(this, (msg) => _ = UserPairStickyPauseAndRemove(msg.UserData));
         Mediator.Subscribe<ZoneSwitchEndMessage>(this, (msg) => _ = PauseServerConnection());
         Mediator.Subscribe<ResumeSyncMessage>(this, (msg) => _ = ResumeServerConnection());
@@ -433,13 +434,31 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         return Task.CompletedTask;
     }
 
-    public async Task PauseAsync(UserData userData, PauseReason reason)
+    public async Task PauseAsync(UserData userData, PauseReason reason, PauseDuration? pauseDuration)
     {
         var pair = _pairManager.GetOnlineUserPairs().Single(p => p.UserPair != null && p.UserData == userData);
         var perm = pair.UserPair!.OwnPermissions;
         perm.SetPaused(paused: true);
         await UserSetPairPermissions(new UserPermissionsDto(userData, perm)).ConfigureAwait(false);
         _serverManager.SetPauseReasonForUid(userData.UID, reason);
+        if (pauseDuration != null && pauseDuration != PauseDuration.Indefinitely)
+            _serverManager.SetPauseTimeoutForUid(userData.UID, pauseDuration.Value);
+    }
+
+    public async Task UnPauseAsync(UserData userData, bool notification = false)
+    {
+        var uid = userData.UID;
+        var pair = _pairManager.GetPairByUID(uid);
+        if (pair == null)
+        {
+            Logger.LogWarning("Called to unpause user but UID does not exist: {uid}", uid);
+            return;
+        }
+        var perm = pair.UserPair!.OwnPermissions;
+        perm.SetPaused(paused: false);
+        await UserSetPairPermissions(new UserPermissionsDto(userData, perm)).ConfigureAwait(false);
+        if (notification)
+            Mediator.Publish(new NotificationMessage("Auto Unpause", $"Auto unpausing UID/Alias: {pair.UserData.AliasOrUID}", NotificationType.Info));
     }
 
     // Perma pause is basically like blacklisting a user on sync


### PR DESCRIPTION
- The UI indicator for pair Sfx fades over time to visually indicate last played time
- Added ZoneSync-only pair filtering in the ZoneSync settings
- Added pair highlighting based on TargetType in the main UI and PAV
  - Green = Target
  - Yellow = MouseOver
  - Blue = SoftTarget
- Added the ability to SoftTarget pairs while hovering in the main UI and PAV
  - Main UI Settings -> Interface -> PlayerSync UI
- Added the PlayerSync context menu items to be accessible via SoftTarget (someone needs to test with a controller)
- Added timed pause and auto unpause features
  - You can now set to auto unpause for VRAM/Triangle and height thresholds (in the threshold settings for each feature)
  - You can manually pause a pair, or pause them for 30 minutes, 4 hours, 8 hours
  - Renamed "Keep Paused" to "Block Pairing"