### PR TITLE
avoid releasing semaphore on cancelled await

### DIFF
--- a/PlayerSync/Interop/Ipc/IpcCallerGlamourer.cs
+++ b/PlayerSync/Interop/Ipc/IpcCallerGlamourer.cs
@@ -157,11 +157,9 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
     public async Task RevertAsync(ILogger logger, GameObjectHandler handler, Guid applicationId, CancellationToken token)
     {
         if ((!APIAvailable) || _dalamudUtil.IsZoning) return;
-        bool acquired = false;
+        await _redrawManager.RedrawSemaphore.WaitAsync(token).ConfigureAwait(false);
         try
         {
-            await _redrawManager.RedrawSemaphore.WaitAsync(token).ConfigureAwait(false);
-            acquired = true; // only release what we actually took (a cancelled WaitAsync acquires nothing)
             // science
             //await _redrawManager.CoalescedRedrawAsync(logger, handler, applicationId, (chara) =>
             await _redrawManager.PenumbraRedrawInternalAsync(logger, handler, applicationId, (chara) =>
@@ -184,7 +182,7 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
         }
         finally
         {
-            if (acquired) _redrawManager.RedrawSemaphore.Release();
+            _redrawManager.RedrawSemaphore.Release();
         }
     }
 

--- a/PlayerSync/Interop/Ipc/IpcCallerGlamourer.cs
+++ b/PlayerSync/Interop/Ipc/IpcCallerGlamourer.cs
@@ -157,9 +157,11 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
     public async Task RevertAsync(ILogger logger, GameObjectHandler handler, Guid applicationId, CancellationToken token)
     {
         if ((!APIAvailable) || _dalamudUtil.IsZoning) return;
+        bool acquired = false;
         try
         {
             await _redrawManager.RedrawSemaphore.WaitAsync(token).ConfigureAwait(false);
+            acquired = true; // only release what we actually took (a cancelled WaitAsync acquires nothing)
             // science
             //await _redrawManager.CoalescedRedrawAsync(logger, handler, applicationId, (chara) =>
             await _redrawManager.PenumbraRedrawInternalAsync(logger, handler, applicationId, (chara) =>
@@ -182,7 +184,7 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
         }
         finally
         {
-            _redrawManager.RedrawSemaphore.Release();
+            if (acquired) _redrawManager.RedrawSemaphore.Release();
         }
     }
 

--- a/PlayerSync/Interop/Ipc/IpcCallerPenumbra.cs
+++ b/PlayerSync/Interop/Ipc/IpcCallerPenumbra.cs
@@ -255,9 +255,11 @@ public sealed class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCa
     public async Task RedrawAsync(ILogger logger, GameObjectHandler handler, Guid applicationId, CancellationToken token)
     {
         if (!APIAvailable || _dalamudUtil.IsZoning) return;
+        bool acquired = false;
         try
         {
             await _redrawManager.RedrawSemaphore.WaitAsync(token).ConfigureAwait(false);
+            acquired = true; // only release what we actually took (a cancelled WaitAsync acquires nothing)
             // science
             //await _redrawManager.CoalescedRedrawAsync(logger, handler, applicationId, (chara) =>
             await _redrawManager.PenumbraRedrawInternalAsync(logger, handler, applicationId, (chara) =>
@@ -269,7 +271,7 @@ public sealed class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCa
         }
         finally
         {
-            _redrawManager.RedrawSemaphore.Release();
+            if (acquired) _redrawManager.RedrawSemaphore.Release();
         }
     }
 

--- a/PlayerSync/Interop/Ipc/IpcCallerPenumbra.cs
+++ b/PlayerSync/Interop/Ipc/IpcCallerPenumbra.cs
@@ -255,11 +255,9 @@ public sealed class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCa
     public async Task RedrawAsync(ILogger logger, GameObjectHandler handler, Guid applicationId, CancellationToken token)
     {
         if (!APIAvailable || _dalamudUtil.IsZoning) return;
-        bool acquired = false;
+        await _redrawManager.RedrawSemaphore.WaitAsync(token).ConfigureAwait(false);
         try
         {
-            await _redrawManager.RedrawSemaphore.WaitAsync(token).ConfigureAwait(false);
-            acquired = true; // only release what we actually took (a cancelled WaitAsync acquires nothing)
             // science
             //await _redrawManager.CoalescedRedrawAsync(logger, handler, applicationId, (chara) =>
             await _redrawManager.PenumbraRedrawInternalAsync(logger, handler, applicationId, (chara) =>
@@ -271,7 +269,7 @@ public sealed class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCa
         }
         finally
         {
-            if (acquired) _redrawManager.RedrawSemaphore.Release();
+            _redrawManager.RedrawSemaphore.Release();
         }
     }
 


### PR DESCRIPTION
cancelled awaits can cause these semaphores to be released without being acquired