### PR TITLE
Add preloadplaylist command for djs

### DIFF
--- a/PlayerSync/MareConfiguration/Configurations/MareConfig.cs
+++ b/PlayerSync/MareConfiguration/Configurations/MareConfig.cs
@@ -115,6 +115,7 @@ public class MareConfig : IMareConfiguration
     public bool EnableColorWaveNotification { get; set; } = true;
     public NotificationLocation PairRequestNotification { get; set; } = NotificationLocation.Both;
     public bool LifestreamInvitesDirectPairsOnly { get; set; } = false;
+    public string LastPreloadPlaylistFolder { get; set; } = string.Empty;
 
     // Experimentals
     public bool UseQueuedCharacterDataApplication {  get; set; } = false;

--- a/PlayerSync/Plugin.cs
+++ b/PlayerSync/Plugin.cs
@@ -264,7 +264,11 @@ public sealed class Plugin : IDalamudPlugin
                 s.GetRequiredService<FileDialogManager>(), s.GetRequiredService<MareMediator>()));
             collection.AddScoped((s) => new CommandManagerService(commandManager, s.GetRequiredService<PerformanceCollectorService>(),
                 s.GetRequiredService<ServerConfigurationManager>(), s.GetRequiredService<CacheMonitor>(), s.GetRequiredService<ApiController>(),
-                s.GetRequiredService<MareMediator>(), s.GetRequiredService<MareConfigService>(), s.GetRequiredService<ZoneSyncConfigService>(), chatGui, pluginLog));
+                s.GetRequiredService<MareMediator>(), s.GetRequiredService<MareConfigService>(), s.GetRequiredService<ZoneSyncConfigService>(),
+                s.GetRequiredService<FileDialogManager>(), s.GetRequiredService<IpcManager>(),
+                s.GetRequiredService<FileCacheManager>(), s.GetRequiredService<FileUploadManager>(),
+                s.GetRequiredService<DalamudUtilService>(),
+                chatGui, pluginLog));
             collection.AddScoped((s) => new UiSharedService(s.GetRequiredService<ILogger<UiSharedService>>(), s.GetRequiredService<IpcManager>(), s.GetRequiredService<ApiController>(),
                 s.GetRequiredService<CacheMonitor>(), s.GetRequiredService<FileDialogManager>(), s.GetRequiredService<MareConfigService>(), s.GetRequiredService<DalamudUtilService>(),
                 pluginInterface, textureProvider, s.GetRequiredService<Dalamud.Localization>(), s.GetRequiredService<ServerConfigurationManager>(), s.GetRequiredService<TokenProvider>(),

--- a/PlayerSync/Services/CommandManagerService.cs
+++ b/PlayerSync/Services/CommandManagerService.cs
@@ -1,4 +1,6 @@
 ﻿using Dalamud.Game.Command;
+using MareSynchronos.Interop.Ipc;
+using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Plugin.Services;
 using MareSynchronos.FileCache;
 using MareSynchronos.MareConfiguration;
@@ -7,8 +9,11 @@ using MareSynchronos.Services.Mediator;
 using MareSynchronos.Services.ServerConfiguration;
 using MareSynchronos.UI;
 using MareSynchronos.WebAPI;
+using MareSynchronos.WebAPI.Files;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using MareSynchronos.Utils;
 
 namespace MareSynchronos.Services;
@@ -26,9 +31,19 @@ public sealed class CommandManagerService : IDisposable
     private readonly CacheMonitor _cacheMonitor;
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly ZoneSyncConfigService _zoneSyncConfigService;
+    private readonly FileDialogManager _fileDialogManager;
+    private readonly IpcManager _ipcManager;
+    private readonly FileCacheManager _fileCacheManager;
+    private readonly FileUploadManager _fileUploadManager;
+    private readonly DalamudUtilService _dalamudUtil;
 
     private readonly IChatGui _chat;
     private readonly IPluginLog _log;
+
+    private sealed record PenumbraOption(
+        [property: JsonPropertyName("Files")] Dictionary<string, string>? Files);
+    private sealed record PenumbraGroup(
+        [property: JsonPropertyName("Options")] List<PenumbraOption>? Options);
 
     /// <summary>
     /// The alias to reference in user-facing text. "/sync" if available, otherwise "/psync".
@@ -44,6 +59,11 @@ public sealed class CommandManagerService : IDisposable
         MareMediator mediator,
         MareConfigService mareConfigService,
         ZoneSyncConfigService zoneSyncConfigService,
+        FileDialogManager fileDialogManager,
+        IpcManager ipcManager,
+        FileCacheManager fileCacheManager,
+        FileUploadManager fileUploadManager,
+        DalamudUtilService dalamudUtil,
         IChatGui chat,
         IPluginLog log)
     {
@@ -55,6 +75,11 @@ public sealed class CommandManagerService : IDisposable
         _mediator = mediator;
         _mareConfigService = mareConfigService;
         _zoneSyncConfigService = zoneSyncConfigService;
+        _fileDialogManager = fileDialogManager;
+        _ipcManager = ipcManager;
+        _fileCacheManager = fileCacheManager;
+        _fileUploadManager = fileUploadManager;
+        _dalamudUtil = dalamudUtil;
         _chat = chat;
         _log = log;
 
@@ -297,6 +322,97 @@ public sealed class CommandManagerService : IDisposable
         else if (string.Equals(splitArgs[0], "settings", StringComparison.OrdinalIgnoreCase))
         {
             _mediator.Publish(new UiToggleMessage(typeof(SettingsUi)));
+        }
+        else if (string.Equals(splitArgs[0], "preloadplaylist", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!_apiController.IsConnected)
+            {
+                _chat.PrintError("[PlayerSync] Not connected to server.");
+                return;
+            }
+            var savedDir = _mareConfigService.Current.LastPreloadPlaylistFolder;
+            var startDir = !string.IsNullOrEmpty(savedDir) && Directory.Exists(savedDir)
+                ? savedDir
+                : _ipcManager.Penumbra.ModDirectory;
+            _fileDialogManager.OpenFileDialog("Select Penumbra Group JSON", ".json", (ok, paths) =>
+            {
+                if (!ok || paths.FirstOrDefault() is not string path) return;
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    _mareConfigService.Current.LastPreloadPlaylistFolder = dir;
+                    _mareConfigService.Save();
+                }
+                _ = Task.Run(() => PreloadPlaylistAsync(path));
+            }, 1, string.IsNullOrEmpty(startDir) ? null : startDir);
+        }
+    }
+
+    private async Task PreloadPlaylistAsync(string jsonPath)
+    {
+        Task Print(string msg) => _dalamudUtil.RunOnFrameworkThread(() => _chat.Print(msg));
+        Task PrintError(string msg) => _dalamudUtil.RunOnFrameworkThread(() => _chat.PrintError(msg));
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(jsonPath).ConfigureAwait(false);
+            var group = JsonSerializer.Deserialize<PenumbraGroup>(json);
+
+            var modDir = Path.GetDirectoryName(jsonPath)!;
+            var scdPaths = (group?.Options ?? [])
+                .SelectMany(o => o.Files ?? [])
+                .Where(kv => kv.Value.EndsWith(".scd", StringComparison.OrdinalIgnoreCase))
+                .Select(kv => Path.Combine(modDir, kv.Value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (scdPaths.Length == 0)
+            {
+                await Print("[PlayerSync] No SCD files found in that group.").ConfigureAwait(false);
+                return;
+            }
+
+            await Print($"[PlayerSync] Found {scdPaths.Length} SCD file(s), uploading...").ConfigureAwait(false);
+
+            var cacheEntries = _fileCacheManager.GetFileCachesByPaths(scdPaths);
+            var hashes = cacheEntries.Values
+                .Where(e => e != null)
+                .Select(e => e!.Hash)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            // SCDs that never resolved to a cache entry (missing on disk, outside the
+            // Penumbra mod folder, etc.) can't be uploaded — count them as failures.
+            var uncached = cacheEntries
+                .Where(kv => kv.Value == null)
+                .Select(kv => kv.Key)
+                .ToList();
+
+            var progress = new Progress<string>(msg => _log.Debug("[PreloadPlaylist] {msg}", msg));
+            var failed = await _fileUploadManager.UploadFiles(hashes, progress).ConfigureAwait(false);
+
+            var pushed = hashes.Count - failed.Count;
+
+            // Upload failures come back as hashes; map them to file names.
+            var uploadFailures = failed
+                .Select(h => cacheEntries.FirstOrDefault(kv =>
+                    kv.Value != null && string.Equals(kv.Value!.Hash, h, StringComparison.OrdinalIgnoreCase)).Key ?? h)
+                .Select(p => $"{Path.GetFileName(p)} (upload failed)");
+
+            // Uncached SCDs never resolved to a cache entry and are already paths.
+            var uncachedFailures = uncached
+                .Select(p => $"{Path.GetFileName(p)} (file missing)");
+
+            var failedNames = uploadFailures.Concat(uncachedFailures).ToList();
+
+            await Print($"[PlayerSync] SCD preload done — {pushed} uploaded, {failedNames.Count} failed.").ConfigureAwait(false);
+            if (failedNames.Count > 0)
+                await PrintError($"[PlayerSync] Failed files: {string.Join(", ", failedNames)}").ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "PreloadPlaylist failed");
+            await PrintError($"[PlayerSync] SCD preload failed: {ex.Message}").ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Adds a highly demanded feature that will upload a single playlist (group.json in a mod). In one background command. Previously, djs would need to play every song in front of a synced pair before performing to avoid long delays in loading for the audience.

The command is undocumented to avoid abuse.