### PR TITLE
Clarify preload notification titles

### DIFF
--- a/PlayerSync/Services/PreloaderService.cs
+++ b/PlayerSync/Services/PreloaderService.cs
@@ -31,12 +31,9 @@ public sealed class PreloaderService
         _mediator = mediator;
         _log = log;
     }
-
+    
     public async Task RunAsync(string jsonPath)
     {
-        void Notify(string msg, NotificationType type = NotificationType.Info) =>
-            _mediator.Publish(new NotificationMessage("PlayerSync", msg, type));
-
         try
         {
             var json = await File.ReadAllTextAsync(jsonPath).ConfigureAwait(false);
@@ -51,11 +48,11 @@ public sealed class PreloaderService
 
             if (filePaths.Length == 0)
             {
-                Notify("No files found in that group.");
+                _mediator.Publish(new NotificationMessage("No Files Found", "No files found in that group.", NotificationType.Info));
                 return;
             }
 
-            Notify($"Found {filePaths.Length} file(s), uploading...");
+            _mediator.Publish(new NotificationMessage("Preload Started", $"Found {filePaths.Length} file(s), uploading...", NotificationType.Info));
 
             var cacheEntries = _fileCacheManager.GetFileCachesByPaths(filePaths);
             var hashes = cacheEntries.Values
@@ -88,14 +85,14 @@ public sealed class PreloaderService
 
             var failedNames = uploadFailures.Concat(uncachedFailures).ToList();
 
-            Notify($"Preload done — {pushed} uploaded, {failedNames.Count} failed.");
+            _mediator.Publish(new NotificationMessage("Preload Complete", $"Preload done — {pushed} uploaded, {failedNames.Count} failed.", NotificationType.Info));
             if (failedNames.Count > 0)
-                Notify($"Failed files: {string.Join(", ", failedNames)}", NotificationType.Warning);
+                _mediator.Publish(new NotificationMessage("Preload Failures", $"Failed files: {string.Join(", ", failedNames)}", NotificationType.Warning));
         }
         catch (Exception ex)
         {
             _log.Error(ex, "PreloadPlaylist failed");
-            Notify($"Preload failed: {ex.Message}", NotificationType.Error);
+            _mediator.Publish(new NotificationMessage("Preload Failed", $"Preload failed: {ex.Message}", NotificationType.Error));
         }
     }
 }

--- a/PlayerSync/UI/SettingsUi.Transfers.cs
+++ b/PlayerSync/UI/SettingsUi.Transfers.cs
@@ -265,12 +265,12 @@ public partial class SettingsUi
     {
         _uiShared.BigText("Preload");
         ImGuiHelpers.ScaledDummy(2);
-        ImGui.TextUnformatted("Upload all replacement files from one or more Penumbra group JSON files so paired users can download them immediately.");
+        ImGui.TextWrapped("Upload all replacement files from one or more Penumbra group JSON files so paired users can download them immediately.");
         ImGuiHelpers.ScaledDummy(4);
 
         if (!_apiController.IsConnected)
         {
-            ImGui.TextColored(ImGuiColors.DalamudYellow, "You must be connected to the server to preload files.");
+            ImGui.TextColoredWrapped(ImGuiColors.DalamudYellow, "You must be connected to the server to preload files.");
             return;
         }
 


### PR DESCRIPTION
Add clearer headers per notification to match the action.
Make meditator calls consistent with the project.