### PR TITLE
First pass at adapting Solona's crash research

### DIFF
--- a/PlayerSync/Interop/SkeletonMappingFix.cs
+++ b/PlayerSync/Interop/SkeletonMappingFix.cs
@@ -38,34 +38,51 @@ internal unsafe class SkeletonMappingFix : IHostedService, IDisposable
 
     private void SetupSkeletonMappingDetour(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices, hkArray<short>* dstBoneToTrackIndices, hkArray<short>* dstTrackToBoneIndices)
     {
-        ResizeIfNecessary(skeletonMapper, animationBinding, srcBoneToTrackIndices);
-        _setupSkeletonMappingHook!.Original!.Invoke(skeletonMapper, animationBinding, srcBoneToTrackIndices, dstBoneToTrackIndices, dstTrackToBoneIndices);
+        if (ResizeIfNecessary(skeletonMapper, animationBinding, srcBoneToTrackIndices))
+        {
+            _setupSkeletonMappingHook!.Original!.Invoke(skeletonMapper, animationBinding, srcBoneToTrackIndices, dstBoneToTrackIndices, dstTrackToBoneIndices);
+        }
     }
 
-    private void ResizeIfNecessary(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices)
+    // Returns false (and skips the original call) only for a malformed binding with a negative bone index.
+    private bool ResizeIfNecessary(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices)
     {
         if (skeletonMapper == null || animationBinding == null || srcBoneToTrackIndices == null)
         {
-            return;
+            return true;
         }
 
         var skeleton = skeletonMapper->Mapping.SkeletonA.ptr;
         if (skeleton == null)
         {
-            return;
+            return true;
         }
 
-        // The game function resizes `srcBoneToTrackIndices` to fit `skeletonMapper`'s Skeleton A bone count, but just assumes
-        // that `animationBinding`'s `TransformTrackToBoneIndices` has the same number of tracks, which it might not.
+        // The game writes each track index to srcBoneToTrackIndices[boneIndex], indexing by the VALUE from the
+        // binding's TransformTrackToBoneIndices -- so the buffer must fit max(boneIndex) + 1, not the track count
+        // (independent, both untrusted). A negative value writes before the buffer and no growth can make it safe.
         int skeletonBoneCount = skeleton->Bones.Length;
-        int bindingTrackCount = animationBinding->TransformTrackToBoneIndices.Length;
+        var trackToBone = animationBinding->TransformTrackToBoneIndices;
+        int maxBoneIndex = -1;
+        for (int i = 0; i < trackToBone.Length; i++)
+        {
+            int boneIndex = trackToBone[i];
+            if (boneIndex < 0)
+            {
+                _logger.LogWarning("Skipping malformed animation binding with negative bone index {index}.", boneIndex);
+                return false;
+            }
+            if (boneIndex > maxBoneIndex) maxBoneIndex = boneIndex;
+        }
 
-        if (bindingTrackCount > skeletonBoneCount && bindingTrackCount > 0)
+        if (maxBoneIndex >= skeletonBoneCount)
         {
             _logger.LogWarning("Fixing binding issue!");
             int successFlag = 0;
-            _hkArrayUtilReserve(&successFlag, (void*)_globalHavokAllocator, srcBoneToTrackIndices, bindingTrackCount, sizeof(short));
+            _hkArrayUtilReserve(&successFlag, (void*)_globalHavokAllocator, srcBoneToTrackIndices, maxBoneIndex + 1, sizeof(short));
         }
+
+        return true;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)

--- a/PlayerSync/Interop/SkeletonMappingFix.cs
+++ b/PlayerSync/Interop/SkeletonMappingFix.cs
@@ -17,13 +17,17 @@ internal unsafe class SkeletonMappingFix : IHostedService, IDisposable
     private readonly ILogger _logger;
     private readonly IGameInteropProvider _gameInteropProvider;
 
+    // How to find: Look for the only usage of `hkaDefaultAnimationControlMapperData::`vftable'`, this will be the last function called there.
     private delegate void SetupSkeletonMappingDelegate(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices, hkArray<short>* dstBoneToTrackIndices, hkArray<short>* dstTrackToBoneIndices);
     [Signature("4C 89 4C 24 ?? 4C 89 44 24 ?? 55 53 56", DetourName = nameof(SetupSkeletonMappingDetour))]
     private readonly Hook<SetupSkeletonMappingDelegate>? _setupSkeletonMappingHook;
 
+    // How to find: This is `hkArrayUtil::_reserve`, which is in ClientStructs' data.yml despite not being added to the code.
     [Signature("48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 41 56 48 83 EC 20 8B 74 24 50 49 8B F8 45 8B 40 0C")]
     private readonly delegate* unmanaged<int*, void*, void*, int, int, void> _hkArrayUtilReserve;
 
+    // How to find: this is the second parameter of almost all calls to `hkArrayUtil::_reserve` and the first to `hkArrayUtil::_reserveMore`.
+    // Sig the `lea` instruction where it's used.
     private const string _globalHavokAllocatorSig = "48 8D 15 ?? ?? ?? ?? 45 8B CF 48 8D 4D 68";
     private readonly nint _globalHavokAllocator; // hkMemoryAllocator*
 

--- a/PlayerSync/Interop/SkeletonMappingFix.cs
+++ b/PlayerSync/Interop/SkeletonMappingFix.cs
@@ -1,0 +1,87 @@
+﻿using Dalamud.Hooking;
+using Dalamud.Plugin.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FFXIVClientStructs.Havok.Animation.Mapper;
+using FFXIVClientStructs.Havok.Animation.Animation;
+using FFXIVClientStructs.Havok.Common.Base.Container.Array;
+using Dalamud.Utility.Signatures;
+
+namespace PlayerSync.Interop;
+
+internal unsafe class SkeletonMappingFix : IHostedService, IDisposable
+{
+    private readonly ILogger _logger;
+    private readonly IGameInteropProvider _gameInteropProvider;
+
+    private delegate void SetupSkeletonMappingDelegate(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices, hkArray<short>* dstBoneToTrackIndices, hkArray<short>* dstTrackToBoneIndices);
+    [Signature("4C 89 4C 24 ?? 4C 89 44 24 ?? 55 53 56", DetourName = nameof(SetupSkeletonMappingDetour))]
+    private readonly Hook<SetupSkeletonMappingDelegate>? _setupSkeletonMappingHook;
+
+    [Signature("48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 41 56 48 83 EC 20 8B 74 24 50 49 8B F8 45 8B 40 0C")]
+    private readonly delegate* unmanaged<int*, void*, void*, int, int, void> _hkArrayUtilReserve;
+
+    private const string _globalHavokAllocatorSig = "48 8D 15 ?? ?? ?? ?? 45 8B CF 48 8D 4D 68";
+    private readonly nint _globalHavokAllocator; // hkMemoryAllocator*
+
+    public SkeletonMappingFix(ILogger<SkeletonMappingFix> logger, IGameInteropProvider gameInteropProvider, ISigScanner sigScanner)
+    {
+        _logger = logger;
+        _gameInteropProvider = gameInteropProvider;
+
+        _gameInteropProvider.InitializeFromAttributes(this);
+        _globalHavokAllocator = sigScanner.GetStaticAddressFromSig(_globalHavokAllocatorSig);
+    }
+
+    private void SetupSkeletonMappingDetour(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices, hkArray<short>* dstBoneToTrackIndices, hkArray<short>* dstTrackToBoneIndices)
+    {
+        ResizeIfNecessary(skeletonMapper, animationBinding, srcBoneToTrackIndices);
+        _setupSkeletonMappingHook!.Original!.Invoke(skeletonMapper, animationBinding, srcBoneToTrackIndices, dstBoneToTrackIndices, dstTrackToBoneIndices);
+    }
+
+    private void ResizeIfNecessary(hkaSkeletonMapper* skeletonMapper, hkaAnimationBinding* animationBinding, hkArray<short>* srcBoneToTrackIndices)
+    {
+        if (skeletonMapper == null || animationBinding == null || srcBoneToTrackIndices == null)
+        {
+            return;
+        }
+
+        var skeleton = skeletonMapper->Mapping.SkeletonA.ptr;
+        if (skeleton == null)
+        {
+            return;
+        }
+
+        // The game function resizes `srcBoneToTrackIndices` to fit `skeletonMapper`'s Skeleton A bone count, but just assumes
+        // that `animationBinding`'s `TransformTrackToBoneIndices` has the same number of tracks, which it might not.
+        int skeletonBoneCount = skeleton->Bones.Length;
+        int bindingTrackCount = animationBinding->TransformTrackToBoneIndices.Length;
+
+        if (bindingTrackCount > skeletonBoneCount && bindingTrackCount > 0)
+        {
+            _logger.LogWarning("Fixing binding issue!");
+            int successFlag = 0;
+            _hkArrayUtilReserve(&successFlag, (void*)_globalHavokAllocator, srcBoneToTrackIndices, bindingTrackCount, sizeof(short));
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _setupSkeletonMappingHook?.Enable();
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _setupSkeletonMappingHook?.Disable();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _setupSkeletonMappingHook?.Dispose();
+    }
+}

--- a/PlayerSync/Plugin.cs
+++ b/PlayerSync/Plugin.cs
@@ -30,6 +30,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NReco.Logging.File;
 using PlayerSync.FileCache;
+using PlayerSync.Interop;
 using PlayerSync.PlayerData.Pairs;
 using PlayerSync.Services;
 using PlayerSync.Validation;
@@ -99,6 +100,8 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddSingleton(new Dalamud.Localization("PlayerSync.Localization.", "", useEmbedded: true));
 
             collection.AddSingleton<IDataManager>(gameData);
+            collection.AddSingleton(gameInteropProvider);
+            collection.AddSingleton(sigScanner);
 
             // add mare related singletons
             collection.AddSingleton<MareMediator>();
@@ -291,6 +294,7 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddHostedService(p => p.GetRequiredService<PairContextMenuHandler>());
             collection.AddHostedService(p => p.GetRequiredService<JsonDataTypeHandlerService>());
             collection.AddHostedService(p => p.GetRequiredService<AnimationBindGuard>());
+            collection.AddHostedService<SkeletonMappingFix>();
         })
         .Build();
 


### PR DESCRIPTION
I did a fair bit of changes like proper parameter types and names, better havok allocator locating, using the actual havok structs, not allocating the success flag on the heap, removing unneeded logging, etc.
It would be cool if ClientStructs had hkMemoryAllocator as a type but oh well.