### PR TITLE
Fix for duplicate downloads and file IO collisions

### DIFF
--- a/PlayerSync/PlayerData/Handlers/PairHandler.cs
+++ b/PlayerSync/PlayerData/Handlers/PairHandler.cs
@@ -770,14 +770,14 @@ public sealed class PairHandler : DisposableMediatorSubscriberBase
                     return;
                 }
 
-                toDownloadReplacements = TryCalculateModdedDictionary(applicationBase, charaData, compressedAlternateUsage, ActiveCompressionRedirects, out locallyPresentFiles, out moddedPaths, downloadToken);
-
                 if (toDownloadReplacements.TrueForAll(c => _downloadManager.ForbiddenTransfers.Exists(f => string.Equals(f.Hash, c.Hash, StringComparison.Ordinal))))
                 {
                     break;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(2), downloadToken).ConfigureAwait(false);
+
+                toDownloadReplacements = TryCalculateModdedDictionary(applicationBase, charaData, compressedAlternateUsage, ActiveCompressionRedirects, out locallyPresentFiles, out moddedPaths, downloadToken);
             }
 
             if (!await _playerPerformanceService.CheckBothThresholds(this, charaData).ConfigureAwait(false))

--- a/PlayerSync/WebAPI/Files/FileDownloadManager.cs
+++ b/PlayerSync/WebAPI/Files/FileDownloadManager.cs
@@ -473,6 +473,10 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
                 {
                     Logger.LogDebug(ex, "{hash}: Detected cancellation of direct download, discarding file.", directDownload.Hash);
                 }
+                else
+                {
+                    Logger.LogError(ex, "{hash}: Error during direct download.", directDownload.Hash);
+                }
 
                 try
                 {
@@ -485,8 +489,6 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 
                 // wait to release the claim until after we've dealt with the temp file
                 _orchestrator.TryReleaseFileDownloadClaim(_downloadManagerClaimId, directDownload.Hash);
-
-                Logger.LogError(ex, "{hash}: Error during direct download.", directDownload.Hash);
 
                 return;
             }

--- a/PlayerSync/WebAPI/Files/FileDownloadManager.cs
+++ b/PlayerSync/WebAPI/Files/FileDownloadManager.cs
@@ -28,7 +28,8 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
     private readonly object _downloadInfoLock = new object();
     private readonly List<ThrottledStream> _activeDownloadStreams;
     private static int _downloadHaltRefCount;
-    private readonly ConcurrentDictionary<string, byte> _reportedHashes = new(StringComparer.OrdinalIgnoreCase);
+    private List<DownloadFileTransfer> _downloadsPendingOtherManagers = [];
+    private readonly Guid _downloadManagerClaimId = Guid.NewGuid();
 
     public FileDownloadManager(ILogger<FileDownloadManager> logger, MareMediator mediator,
         FileTransferOrchestrator orchestrator,
@@ -122,7 +123,15 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 
     protected override void Dispose(bool disposing)
     {
+        foreach (var download in CurrentDownloads)
+        {
+            _orchestrator.TryReleaseFileDownloadClaim(_downloadManagerClaimId, download.Hash);
+        }
+
+        _downloadsPendingOtherManagers.Clear();
+
         ClearDownload();
+
         lock (_downloadInfoLock)
         {
             foreach (var stream in _activeDownloadStreams.ToList())
@@ -207,7 +216,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
                 throw new InvalidDataException($"Http error {ex.StatusCode} (cancelled: {ct.IsCancellationRequested}): {requestUrl}", ex);
             }
 
-            return;
+            throw;
         }
 
         ThrottledStream? stream = null;
@@ -279,7 +288,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 
     public async Task<List<DownloadFileTransfer>> InitiateDownloadList(GameObjectHandler gameObjectHandler, List<FileReplacementData> fileReplacement, CompressedAlternateUsage compressedAlternateUsage, Dictionary<string, string> compressedSubstitutions, HashSet<string> locallyPresentFiles, CancellationToken ct)
     {
-        Logger.LogDebug("Download start: {id}", gameObjectHandler.Name);
+        Logger.LogDebug("FILES-{manager} Download starting for id: {id}", _downloadManagerClaimId, gameObjectHandler.Name);
 
         List<DownloadFileDto> downloadFileInfoFromService =
         [
@@ -333,8 +342,24 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
             }
         }
 
-        CurrentDownloads = downloadFileInfoFromService.Distinct().Select(d => new DownloadFileTransfer(d))
+        var allDownloads = downloadFileInfoFromService.Distinct().Select(d => new DownloadFileTransfer(d))
             .Where(d => d.CanBeTransferred).ToList();
+
+        _downloadsPendingOtherManagers.Clear();
+
+        foreach (var download in allDownloads)
+        {
+            if (_orchestrator.TryClaimFileDownload(_downloadManagerClaimId, download))
+            {
+                CurrentDownloads.Add(download);
+            }
+            else
+            {
+                _downloadsPendingOtherManagers.Add(download);
+            }
+        }
+
+        Logger.LogTrace("FILES-{manager} has claimed download count: {claimed}, pending other managers count: {others}", _downloadManagerClaimId, CurrentDownloads.Count, _downloadsPendingOtherManagers.Count);
 
         return CurrentDownloads;
     }
@@ -374,7 +399,11 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
         async (directDownload, token) =>
         {
             if (!_downloadStatus.TryGetValue(directDownload.DirectDownloadUrl!, out var downloadTracker))
+            {
+                _orchestrator.TryReleaseFileDownloadClaim(_downloadManagerClaimId, directDownload.Hash);
+
                 return;
+            }
 
             Progress<long> progress = new((bytesDownloaded) =>
             {
@@ -397,7 +426,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
             catch (OperationCanceledException ex)
             {
                 Logger.LogDebug("{hash}: Detected cancellation of file queued for direct download, canceling.", directDownload.Hash);
-                ClearDownload();
+                _orchestrator.TryReleaseFileDownloadClaim(_downloadManagerClaimId, directDownload.Hash);
                 return;
             }
 
@@ -428,21 +457,29 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 #endif
                 await DownloadFileThrottled(new Uri(directDownload.DirectDownloadUrl!), tempFilename, directDownload.Hash, progress, munge, token, withToken: false).ConfigureAwait(false);
             }
-            catch (OperationCanceledException ex)
-            {
-                Logger.LogDebug("{hash}: Detected cancellation of direct download, discarding file.", directDownload.Hash);
-                _orchestrator.ReleaseDownloadSlot();
-                File.Delete(tempFilename);
-                Logger.LogDebug(ex, "{hash}: Error during direct download.", directDownload.Hash);
-                ClearDownload();
-                return;
-            }
             catch (Exception ex)
             {
                 _orchestrator.ReleaseDownloadSlot();
-                File.Delete(tempFilename);
+
+                if (ex is OperationCanceledException)
+                {
+                    Logger.LogDebug(ex, "{hash}: Detected cancellation of direct download, discarding file.", directDownload.Hash);
+                }
+
+                try
+                {
+                    File.Delete(tempFilename);
+                }
+                catch (IOException deleteException) // catch this here vs propogating all the way up (file in use, etc.)
+                {
+                    Logger.LogDebug(deleteException, "{hash}: Could not delete temporary file {tempFilename}.", directDownload.Hash, tempFilename);
+                }
+
+                // wait to release the claim until after we've dealt with the temp file
+                _orchestrator.TryReleaseFileDownloadClaim(_downloadManagerClaimId, directDownload.Hash);
+
                 Logger.LogError(ex, "{hash}: Error during direct download.", directDownload.Hash);
-                ClearDownload();
+
                 return;
             }
 
@@ -470,15 +507,71 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
             {
                 _orchestrator.ReleaseDownloadSlot();
                 File.Delete(tempFilename);
+                _orchestrator.TryReleaseFileDownloadClaim(_downloadManagerClaimId, directDownload.Hash); // once file is saved to disk, release the download claim
             }
         });
 
         // Wait for all the direct downloads to complete
         await directDownloadsTask.ConfigureAwait(false);
 
-        Logger.LogDebug("Download end: {id}", gameObjectHandler);
+        if (_downloadsPendingOtherManagers.Count > 0)
+        {
+            await WaitForPendingDownloadsFromOtherManagers(ct).ConfigureAwait(false);
+        }
+
+        Logger.LogDebug("FILES-{manager} Finished a set of downloads for id: {id}", _downloadManagerClaimId, gameObjectHandler);
 
         ClearDownload();
+    }
+
+    private async Task WaitForPendingDownloadsFromOtherManagers(CancellationToken ct)
+    {
+        const int secondsToWaitBeforeTimeout = 30;
+        var timeoutAfterTimeFromNowSeconds = DateTime.UtcNow.AddSeconds(secondsToWaitBeforeTimeout); // we can loop 10 times in PairHandler
+
+        // while a pair may be waiting for another to finish the download, they both need the same file, so they'd both be waiting, and possibly competing for the bandwidth, together
+        while (_downloadsPendingOtherManagers.Count > 0 && DateTime.UtcNow < timeoutAfterTimeFromNowSeconds) // yeah, there should be a more definitive way to do this
+        {
+            ct.ThrowIfCancellationRequested();
+
+            Logger.LogTrace("FILES-{manager} waiting for pending downloads from other managers, total: {others}", _downloadManagerClaimId, _downloadsPendingOtherManagers.Count);
+
+            var stillPending = new List<DownloadFileTransfer>();
+
+            foreach (var download in _downloadsPendingOtherManagers)
+            {
+                if (_fileDbManager.GetFileCacheByHash(download.Hash) != null)
+                {
+                    continue;
+                }
+
+                if (_orchestrator.IsDownloadStillPendingCompletion(download.Hash))
+                {
+                    stillPending.Add(download);
+
+                    continue;
+                }
+                
+                // no file and no claim, so it must have failed
+                // we let this fall through, the PairHandler will pick it up again in next loop
+            }
+
+            _downloadsPendingOtherManagers = stillPending;
+
+            if (_downloadsPendingOtherManagers.Count > 0)
+            {
+                await Task.Delay(250, ct).ConfigureAwait(false);
+            }
+        }
+
+        if (_downloadsPendingOtherManagers.Count > 0)
+        {
+            Logger.LogDebug("FILES-{manager} Timed out after {sec} waiting for {count} pending download(s) from other managers", _downloadManagerClaimId, secondsToWaitBeforeTimeout, _downloadsPendingOtherManagers.Count);
+        }
+        else
+        {
+            Logger.LogDebug("FILES-{manager} Finished waiting for pending downloads from other managers", _downloadManagerClaimId);
+        }
     }
 
     private async Task<List<DownloadFileDto>> FilesGetSizes(List<string> hashes, CancellationToken ct)
@@ -490,13 +583,15 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 
     private async Task ReportFileMissing(string hash, CancellationToken ct)
     {
-        if (!_reportedHashes.TryAdd(hash, 0))
-            return; // we've already reported this
+        if (!_orchestrator.TryAddHashReportedError404(hash))
+        {
+            return; // another manager has already reported this hash missing
+        }
 
         if (!_orchestrator.IsInitialized) throw new InvalidOperationException("FileTransferManager is not initialized");
 
         hash = hash.ToUpperInvariant();
-        Logger.LogWarning("Download reported a 404 error for hash {hash}, reporting it to the FileServer", hash);
+        Logger.LogWarning("FILES-{manager} Download reported a 404 error for hash {hash}, reporting it to the FileServer", _downloadManagerClaimId, hash);
 
         await _orchestrator.SendRequestAsync(HttpMethod.Post, MareFiles.ServerFilesReportFile(_orchestrator.FilesCdnUri!), hash, ct).ConfigureAwait(false);
     }

--- a/PlayerSync/WebAPI/Files/FileDownloadManager.cs
+++ b/PlayerSync/WebAPI/Files/FileDownloadManager.cs
@@ -349,6 +349,14 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
 
         foreach (var download in allDownloads)
         {
+            // ok, listen, the timing on some of this is so tight, this check is actually needed
+            // the 60-90ms timing is real between different pairs and when they get the response for FilesGetSizes
+            // someone else may have already downloaded the file before they even got here
+            if (_fileDbManager.GetFileCacheByHash(download.Hash) != null)
+            {
+                continue; 
+            }
+
             if (_orchestrator.TryClaimFileDownload(_downloadManagerClaimId, download))
             {
                 CurrentDownloads.Add(download);

--- a/PlayerSync/WebAPI/Files/FileTransferOrchestrator.cs
+++ b/PlayerSync/WebAPI/Files/FileTransferOrchestrator.cs
@@ -17,6 +17,9 @@ public class FileTransferOrchestrator : DisposableMediatorSubscriberBase
     private readonly MareConfigService _mareConfig;
     private readonly TokenProvider _tokenProvider;
 
+    private readonly ConcurrentDictionary<string, (Guid, DownloadFileTransfer)> _claimedDownloadFileTransfers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, byte> _hashesReportedError404 = new(StringComparer.OrdinalIgnoreCase);
+
     // Download slots
     private readonly object _semaphoreModificationLock = new();
     private int _availableDownloadSlots;
@@ -114,6 +117,48 @@ public class FileTransferOrchestrator : DisposableMediatorSubscriberBase
         {
             // ignore
         }
+    }
+
+    public bool TryClaimFileDownload(Guid ownerId, DownloadFileTransfer fileTransfer)
+    {
+        Logger.LogTrace("FILES-{manager} attemptiong to claim download for {hash}", ownerId, fileTransfer.Hash);
+
+        var success = _claimedDownloadFileTransfers.TryAdd(fileTransfer.Hash, (ownerId, fileTransfer));
+
+        if (!success)
+        {
+            Logger.LogTrace("FILES-{manager} another manager has already claimed the download for {hash}", ownerId, fileTransfer.Hash);
+        }
+
+        return success;
+    }
+
+    public bool TryReleaseFileDownloadClaim(Guid ownerId, string fileHash)
+    {
+        Logger.LogTrace("FILES-{manager} download claim released for {hash} initiated", ownerId, fileHash);
+        if (!_claimedDownloadFileTransfers.TryGetValue(fileHash, out var claim) || claim.Item1 != ownerId) // not every code path has the DownloadFileTransfer so we need look it up first
+        {
+            Logger.LogTrace("FILES-{manager} download claim released for {hash} failed", ownerId, fileHash);
+
+            return false;
+        }
+
+        // this can fail legitimately for files that were in flight and already marked done when a pair gets unloaded mid download/dispose
+        var success = _claimedDownloadFileTransfers.TryRemove(new KeyValuePair<string, (Guid OwnerId, DownloadFileTransfer Transfer)>(fileHash, claim));
+
+        Logger.LogTrace("FILES-{manager} download claim released for {hash} successfully: {success}", ownerId, fileHash, success);
+
+        return success;
+    }
+
+    public bool IsDownloadStillPendingCompletion(string fileHash)
+    {
+        return _claimedDownloadFileTransfers.TryGetValue(fileHash, out _);
+    }
+
+    public bool TryAddHashReportedError404(string fileHash)
+    {
+        return _hashesReportedError404.TryAdd(fileHash, 0);
     }
 
     public async Task<HttpResponseMessage> SendRequestAsync(HttpMethod method, Uri uri,


### PR DESCRIPTION
- Prevents file IO collisions when multiple DownloadManagers are racing to download the same file
- Prevents multiple downloads of the same file at the same time
- Prevents downloading a file again (dupe) that may have _just_ been downloaded milliseconds ago
- Changes ordering for multiple loop iterations where a comp alt could get inadvertently downloaded twice